### PR TITLE
Update *ring* to 0.9.4.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonwebtoken"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Vincent Prouillet <vincent@wearewizards.io>"]
 license = "MIT"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ error-chain = { version = "0.10", default-features = false }
 serde_json = "1.0"
 serde_derive = "1.0"
 serde = "1.0"
-ring = { version = "0.7", features = ["rsa_signing", "dev_urandom_fallback"] }
+ring = { version = "0.9.4", features = ["rsa_signing", "dev_urandom_fallback"] }
 base64 = "0.5"
-untrusted = "0.3"
+untrusted = "0.5"
 chrono = "0.3"

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -32,7 +32,7 @@ fn sign_hmac(alg: &'static digest::Algorithm, key: &[u8], signing_input: &str) -
     let digest = hmac::sign(&signing_key, signing_input.as_bytes());
 
     Ok(
-        base64::encode_config::<digest::Digest>(&digest, base64::URL_SAFE_NO_PAD)
+        base64::encode_config::<hmac::Signature>(&digest, base64::URL_SAFE_NO_PAD)
     )
 }
 


### PR DESCRIPTION
Before *ring* 0.9.3, it was possible to link multiple versions of *ring* into a program, e.g. if one version depended on *ring* 0.6 and another depended on *ring* 0.9. Unfortunately, this doesn't work, because the linker doesn't know to how to link *ring*'s C/asm code correctly in that kind of situation. *ring* 0.9.3 added a flag to its Cargo.toml to tell the Rust toolchain to stop allowing multiple versions of *ring* to be linked into the same program, to prevent any problems this may cause.

*ring* 0.9.4 was released with an update to make some crates easier to update to 0.9.x.

if you consider this a breaking change, let me know and I'll bump the version number to 3.0.0 instead of 2.0.1.