### PR TITLE
Make the `TokenData` struct public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 .idea/
+.vscode

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,13 +29,14 @@ pub use crypto::{
     verify,
 };
 pub use validation::Validation;
+pub use serialization::TokenData;
 
 
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 
 use errors::{Result, ErrorKind};
-use serialization::{TokenData, from_jwt_part, from_jwt_part_claims, to_jwt_part};
+use serialization::{from_jwt_part, from_jwt_part_claims, to_jwt_part};
 use validation::{validate};
 
 

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -11,7 +11,9 @@ use header::Header;
 /// The return type of a successful call to decode
 #[derive(Debug)]
 pub struct TokenData<T> {
+    /// The decoded JWT header
     pub header: Header,
+    /// The decoded JWT claims
     pub claims: T
 }
 


### PR DESCRIPTION
While upgrading from v1 to v2 of jsonwebtoken, the compiler was complaining that the `TokenData` struct was private, which indeed it it. It's marked `pub` within the `serialization` module, but that module isn't public itself.

I only made `TokenData` public, but could make the entire module public as well.

Happy to explain more or adjust as needed 😄 