### PR TITLE
Fix jwt::decode documentation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Look at `examples/custom_header.rs` for a full working example.
 
 ### Decoding
 ```rust
-let token = decode::<Claims>(&token, "secret", &Validation::default())?;
+let token = decode::<Claims>(&token, "secret".as_ref(), &Validation::default())?;
 // token is a struct with 2 params: header and claims
 ```
 `decode` can error for a variety of reasons:


### PR DESCRIPTION
Apparently jwt::decode expects the secret to be a slice. Thus blindly copying the example code from the readme gives a compilation error.

```
error[E0308]: mismatched types
  --> src/service/auth.rs:43:35
   |
43 |     jwt::decode::<Claims>(&token, "secret", &jwt::Validation::default())
   |                                   ^^^^^^^^ expected slice, found str
   |
   = note: expected type `&[u8]`
              found type `&'static str`
   = help: here are some functions which might fulfill your needs:
           - .as_bytes()
```