### PR TITLE
Implement "none" algorithm

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -12,6 +12,36 @@ struct Claims {
 }
 
 #[test]
+fn sign_none() {
+    let result = sign("hello world", b"", Algorithm::None).unwrap();
+    assert_eq!(result, "");
+}
+
+#[test]
+#[should_panic(expected = "InvalidKey")]
+fn sign_none_with_key() {
+    sign("hello world", b"SomeKey", Algorithm::None).unwrap();
+}
+
+#[test]
+fn verify_none() {
+    let valid = verify("", "hello world", b"", Algorithm::None).unwrap();
+    assert!(valid);
+}
+
+#[test]
+#[should_panic(expected = "InvalidKey")]
+fn verify_none_with_key() {
+    verify("", "hello world", b"SomeKey", Algorithm::None).unwrap();
+}
+
+#[test]
+fn verify_none_with_nonempty_sig() {
+    let valid = verify("SomeSig", "hello world", b"", Algorithm::None).unwrap();
+    assert!(!valid);
+}
+
+#[test]
 fn sign_hs256() {
     let result = sign("hello world", b"secret", Algorithm::HS256).unwrap();
     let expected = "c0zGLzKEFWj0VxWuufTXiRMk5tlI5MbGDAYhzaxIYjo";


### PR DESCRIPTION
This implements the "none" algorithm as defined in RFC 7519 section 6 ("Unsecured JWTs"). This algorithm has a dubious security history but it should be mitigated by two factors:

1) This crate requires explicitly specifying an algorithm for verification. Using this algorithm would require the caller to either specify it or write their own algorithm detection logic.

2) Sign/verify operations will fail if a key is specified. This would prevent misguided algorithm detection logic to use "none" with a key intended for RSA or HMAC.

A variant of this patch is being used internally by a proxy that converts signed JWTs to unsecured JWTs. This is part of a transition plan to use signed JWTs everywhere but this piece is needed for the migration.