### PR TITLE
Add `serde` dependency to example Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 Add the following to Cargo.toml:
 
 ```toml
-jsonwebtoken = "3"
+jsonwebtoken = "4"
 serde_derive = "1"
+serde = "1"
 ```
 
 ## How to use


### PR DESCRIPTION
Hey @Keats ,

New to Rust so apologies if I missed  or overlooked anything obvious!

---

When trying to get started with your lib I got stuck on this compile time error:

![image](https://user-images.githubusercontent.com/2099811/34462360-4e7004b4-ee10-11e7-82e5-3e368dd96d7c.png)

After flailing for a bit I landed on a [serde GitHub issue that had a solution](https://github.com/serde-rs/serde/issues/856).

Notably:

> Adding serde to my dependencies fixes this.

---

So I went ahead and added `serde` to the example `Cargo.toml` in the README. Do let me know if there are any issues here!