### PR TITLE
Update ring dependency to 0.14.6, refactor sign_rsa fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["jwt", "web", "api", "token", "json"]
 serde_json = "1.0"
 serde_derive = "1.0"
 serde = "1.0"
-ring = { version = "0.13", features = ["rsa_signing", "dev_urandom_fallback"] }
+ring = { version = "0.14", features = ["dev_urandom_fallback"] }
 base64 = "0.9"
 untrusted = "0.6"
 chrono = "0.4"

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -66,14 +66,13 @@ fn sign_rsa(alg: Algorithm, key: &[u8], signing_input: &str) -> Result<String> {
     };
 
     let key_pair = Arc::new(
-        signature::RSAKeyPair::from_der(untrusted::Input::from(key))
+        signature::RsaKeyPair::from_der(untrusted::Input::from(key))
             .map_err(|_| ErrorKind::InvalidRsaKey)?,
     );
-    let mut signing_state =
-        signature::RSASigningState::new(key_pair).map_err(|_| ErrorKind::InvalidRsaKey)?;
-    let mut signature = vec![0; signing_state.key_pair().public_modulus_len()];
+    let mut signature = vec![0; key_pair.public_modulus_len()];
+
     let rng = rand::SystemRandom::new();
-    signing_state
+    key_pair
         .sign(ring_alg, &rng, signing_input.as_bytes(), &mut signature)
         .map_err(|_| ErrorKind::InvalidRsaKey)?;
 
@@ -98,7 +97,7 @@ pub fn sign(signing_input: &str, key: &[u8], algorithm: Algorithm) -> Result<Str
 
 /// See Ring RSA docs for more details
 fn verify_rsa(
-    alg: &signature::RSAParameters,
+    alg: &signature::RsaParameters,
     signature: &str,
     signing_input: &str,
     key: &[u8],


### PR DESCRIPTION
I ran into a dependency issue because actix-http requires ring 0.14+. I bumped the version and adjusted the rsa function as needed.

All tests pass, I basically just changed it to the new example in ring's documentation.

* Ring 0.14.6 no longer has a signing state. The
  key_pair itself can call #sign.
* Ring 0.14.6 also doesn't have the rsa feature
  anymore.