### PR TITLE
Support for RSASSA-PSS signing algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ This library currently supports the following:
 - RS256
 - RS384
 - RS512
+- PS256
+- PS384
+- PS512
 - ES256
 - ES384
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -97,7 +97,7 @@ impl StdError for Error {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self.0 {
             ErrorKind::InvalidToken => None,
             ErrorKind::InvalidSignature => None,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -166,5 +166,8 @@ fn generate_algorithm_enum_from_str() {
     assert!(Algorithm::from_str("RS256").is_ok());
     assert!(Algorithm::from_str("RS384").is_ok());
     assert!(Algorithm::from_str("RS512").is_ok());
+    assert!(Algorithm::from_str("PS256").is_ok());
+    assert!(Algorithm::from_str("PS384").is_ok());
+    assert!(Algorithm::from_str("PS512").is_ok());
     assert!(Algorithm::from_str("").is_err());
 }


### PR DESCRIPTION
As specified in https://tools.ietf.org/html/rfc7518#section-3.5

- PS256 - RSASSA-PSS using SHA-256 hash algorithm
- PS384 - RSASSA-PSS using SHA-384 hash algorithm
- PS512 - RSASSA-PSS using SHA-512 hash algorithm

Fixes #92 

This is a breaking change so it's a good chance to release with v7.