### PR TITLE
Add a NONE signature algorithm.

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -30,6 +30,8 @@ pub enum Algorithm {
     RS384,
     /// RSASSA-PKCS1-v1_5 using SHA-512
     RS512,
+    /// No signing will be performed. The resulting signature is thus empty.
+    NONE,
 }
 
 impl Default for Algorithm {
@@ -50,6 +52,7 @@ impl FromStr for Algorithm {
             "RS256" => Ok(Algorithm::RS256),
             "RS384" => Ok(Algorithm::RS384),
             "RS512" => Ok(Algorithm::RS512),
+            "NONE" => Ok(Algorithm::NONE),
             _ => Err(new_error(ErrorKind::InvalidAlgorithmName)),
         }
     }
@@ -64,7 +67,11 @@ fn sign_hmac(alg: &'static digest::Algorithm, key: &[u8], signing_input: &str) -
 }
 
 /// The actual ECDSA signing + encoding
-fn sign_ecdsa(alg: &'static signature::EcdsaSigningAlgorithm, key: &[u8], signing_input: &str) -> Result<String> {
+fn sign_ecdsa(
+    alg: &'static signature::EcdsaSigningAlgorithm,
+    key: &[u8],
+    signing_input: &str,
+) -> Result<String> {
     let signing_key = signature::EcdsaKeyPair::from_pkcs8(alg, untrusted::Input::from(key))?;
     let rng = rand::SystemRandom::new();
     let sig = signing_key.sign(&rng, untrusted::Input::from(signing_input.as_bytes()))?;
@@ -73,7 +80,11 @@ fn sign_ecdsa(alg: &'static signature::EcdsaSigningAlgorithm, key: &[u8], signin
 
 /// The actual RSA signing + encoding
 /// Taken from Ring doc https://briansmith.org/rustdoc/ring/signature/index.html
-fn sign_rsa(alg: &'static signature::RsaEncoding, key: &[u8], signing_input: &str) -> Result<String> {
+fn sign_rsa(
+    alg: &'static signature::RsaEncoding,
+    key: &[u8],
+    signing_input: &str,
+) -> Result<String> {
     let key_pair = Arc::new(
         signature::RsaKeyPair::from_der(untrusted::Input::from(key))
             .map_err(|_| ErrorKind::InvalidRsaKey)?,
@@ -97,12 +108,18 @@ pub fn sign(signing_input: &str, key: &[u8], algorithm: Algorithm) -> Result<Str
         Algorithm::HS384 => sign_hmac(&digest::SHA384, key, signing_input),
         Algorithm::HS512 => sign_hmac(&digest::SHA512, key, signing_input),
 
-        Algorithm::ES256 => sign_ecdsa(&signature::ECDSA_P256_SHA256_FIXED_SIGNING, key, signing_input),
-        Algorithm::ES384 => sign_ecdsa(&signature::ECDSA_P384_SHA384_FIXED_SIGNING, key, signing_input),
+        Algorithm::ES256 => {
+            sign_ecdsa(&signature::ECDSA_P256_SHA256_FIXED_SIGNING, key, signing_input)
+        }
+        Algorithm::ES384 => {
+            sign_ecdsa(&signature::ECDSA_P384_SHA384_FIXED_SIGNING, key, signing_input)
+        }
 
         Algorithm::RS256 => sign_rsa(&signature::RSA_PKCS1_SHA256, key, signing_input),
         Algorithm::RS384 => sign_rsa(&signature::RSA_PKCS1_SHA384, key, signing_input),
         Algorithm::RS512 => sign_rsa(&signature::RSA_PKCS1_SHA512, key, signing_input),
+
+        Algorithm::NONE => Ok("".to_string()),
     }
 }
 
@@ -158,5 +175,6 @@ pub fn verify(
         Algorithm::RS512 => {
             verify_ring(&signature::RSA_PKCS1_2048_8192_SHA512, signature, signing_input, key)
         }
+        Algorithm::NONE => Ok(true),
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -32,6 +32,27 @@ fn verify_hs256() {
 }
 
 #[test]
+fn sign_none() {
+    let result = sign("hello world", b"secret", Algorithm::NONE).unwrap();
+    let expected = "";
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn verify_none_empty() {
+    let sig = "";
+    let valid = verify(sig, "Whatever", b"irrelevant", Algorithm::NONE).unwrap();
+    assert!(valid);
+}
+
+#[test]
+fn verify_none_signature_present() {
+    let sig = "random";
+    let valid = verify(sig, "Whatever", b"irrelevant", Algorithm::NONE).unwrap();
+    assert!(valid);
+}
+
+#[test]
 fn encode_with_custom_header() {
     let my_claims = Claims {
         sub: "b@b.com".to_string(),
@@ -163,8 +184,11 @@ fn generate_algorithm_enum_from_str() {
     assert!(Algorithm::from_str("HS256").is_ok());
     assert!(Algorithm::from_str("HS384").is_ok());
     assert!(Algorithm::from_str("HS512").is_ok());
+    assert!(Algorithm::from_str("ES256").is_ok());
+    assert!(Algorithm::from_str("ES384").is_ok());
     assert!(Algorithm::from_str("RS256").is_ok());
     assert!(Algorithm::from_str("RS384").is_ok());
     assert!(Algorithm::from_str("RS512").is_ok());
+    assert!(Algorithm::from_str("NONE").is_ok());
     assert!(Algorithm::from_str("").is_err());
 }


### PR DESCRIPTION
This algorithm results in empty signatures when signing. Verification
always yields success, whether the signature is empty or not.

PS: apologies for the unrelated formatting changes. rustfmt ran automatically, and this is what it spat out :)