### PR TITLE
Update ring to 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["jwt", "web", "api", "token", "json"]
 serde_json = "1.0"
 serde_derive = "1.0"
 serde = "1.0"
-ring = "0.14.4"
+ring = { version = "0.16", features = ["std"] }
 base64 = "0.10"
-untrusted = "0.6"
 chrono = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ extern crate chrono;
 extern crate ring;
 extern crate serde;
 extern crate serde_json;
-extern crate untrusted;
 
 mod crypto;
 /// All the errors, generated using error-chain


### PR DESCRIPTION
- Update `ring` to 0.16
- Add `std` feature to `ring` (so errors impl `std::error::Error`)
- Remove the now unused `untrusted` dependency, as `ring` now handles that internally.

