### PR TITLE
Updated aud within Validation, including membership validation testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Add support for verifying with modulus/exponent components for RSA
 - Change API for both sign/verify to take a `Key` enum rather than bytes
 - Update to 2018 edition
+- Changed aud field type in Validation to Option<HashSet<String>>.  Audience 
+  validation now tests for "any-of-these" audience membership.
 
 ## 6.0.1 (2019-05-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add support for verifying with modulus/exponent components for RSA
 - Change API for both sign/verify to take a `Key` enum rather than bytes
 - Update to 2018 edition
-- Changed aud field type in Validation to Option<HashSet<String>>.  Audience 
+- Changed aud field type in Validation to `Option<HashSet<String>>`.  Audience 
   validation now tests for "any-of-these" audience membership.
 
 ## 6.0.1 (2019-05-10)

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -3,8 +3,8 @@ use chrono::Utc;
 use serde_json::map::Map;
 use serde_json::{from_value, Value};
 
-use crypto::Algorithm;
-use errors::{new_error, ErrorKind, Result};
+use crate::algorithms::Algorithm;
+use crate::errors::{new_error, ErrorKind, Result};
 
 /// Contains the various validations that are applied after decoding a token.
 ///
@@ -161,7 +161,7 @@ mod tests {
 
     use super::{validate, Validation};
 
-    use errors::ErrorKind;
+    use crate::errors::ErrorKind;
 
     #[test]
     fn exp_in_future_ok() {


### PR DESCRIPTION
- Validation.aud is now `Option<HashSet<String>>`
- audience validation tests for "any of these" membership