### PR TITLE
Add functions to create pems and ders of the public keys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod errors;
 mod header;
 mod keys;
 mod pem_decoder;
+mod pem_encoder;
 mod serialization;
 mod validation;
 
@@ -184,4 +185,34 @@ pub fn decode_header(token: &str) -> Result<Header> {
 /// ```
 pub fn decode_pem(content: &str) -> Result<PemEncodedKey> {
     PemEncodedKey::read(content)
+}
+
+/// TODO
+pub fn encode_rsa_public_pkcs1_pem(modulus: &[u8], exponent: &[u8]) -> Result<String> {
+    pem_encoder::encode_rsa_public_pkcs1_pem(modulus, exponent)
+}
+
+/// TODO
+pub fn encode_rsa_public_pkcs1_der(modulus: &[u8], exponent: &[u8]) -> Result<Vec<u8>> {
+    pem_encoder::encode_rsa_public_pkcs1_der(modulus, exponent)
+}
+
+/// TODO
+pub fn encode_rsa_public_pkcs8_pem(modulus: &[u8], exponent: &[u8]) -> Result<String> {
+    pem_encoder::encode_rsa_public_pkcs8_pem(modulus, exponent)
+}
+
+/// TODO
+pub fn encode_rsa_public_pkcs8_der(modulus: &[u8], exponent: &[u8]) -> Result<Vec<u8>> {
+    pem_encoder::encode_rsa_public_pkcs8_der(modulus, exponent)
+}
+
+/// TODO
+pub fn encode_ec_public_pem(x_coordinate: &[u8]) -> Result<String> {
+    pem_encoder::encode_ec_public_pem(x_coordinate)
+}
+
+/// TODO
+pub fn encode_ec_public_der(x_coordinate: &[u8]) -> Result<Vec<u8>> {
+    pem_encoder::encode_ec_public_der(x_coordinate)
 }

--- a/src/pem_encoder.rs
+++ b/src/pem_encoder.rs
@@ -1,0 +1,100 @@
+use crate::errors::{ErrorKind, Result};
+use simple_asn1::{ASN1Block, BigUint, BigInt, OID};
+use pem::{Pem};
+
+extern crate base64;
+extern crate pem;
+extern crate simple_asn1;
+
+pub fn encode_rsa_public_pkcs1_pem(modulus: &[u8], exponent: &[u8]) -> Result<String> {
+    Ok(pem::encode(&Pem {
+        contents: encode_rsa_public_pkcs1_der(modulus, exponent)?,
+        tag: "RSA PUBLIC KEY".to_string(),
+    }))
+}
+
+pub fn encode_rsa_public_pkcs1_der(modulus: &[u8], exponent: &[u8]) -> Result<Vec<u8>> {
+    match simple_asn1::to_der(&encode_rsa_public_pksc1_asn1(modulus, exponent)) {
+        Ok(bytes) => Ok(bytes),
+        Err(_) => return Err(ErrorKind::InvalidRsaKey)?,
+    }
+}
+
+pub fn encode_rsa_public_pkcs8_pem(modulus: &[u8], exponent: &[u8]) -> Result<String> {
+    Ok(pem::encode(&Pem {
+        contents: encode_rsa_public_pkcs8_der(modulus, exponent)?,
+        tag: "PUBLIC KEY".to_string(),
+    }))
+}
+
+pub fn encode_rsa_public_pkcs8_der(modulus: &[u8], exponent: &[u8]) -> Result<Vec<u8>> {
+    match simple_asn1::to_der(&encode_rsa_public_pksc8_asn1(modulus, exponent)?) {
+        Ok(bytes) => Ok(bytes),
+        Err(_) => return Err(ErrorKind::InvalidRsaKey)?,
+    }
+}
+
+pub fn encode_ec_public_pem(x: &[u8]) -> Result<String> {
+    Ok(pem::encode(&Pem {
+        contents: encode_ec_public_der(x)?,
+        tag: "PUBLIC KEY".to_string(),
+    }))
+}
+
+pub fn encode_ec_public_der(x: &[u8]) -> Result<Vec<u8>> {
+    match simple_asn1::to_der(&encode_ec_public_asn1(x)) {
+        Ok(bytes) => Ok(bytes),
+        Err(_) => return Err(ErrorKind::InvalidEcdsaKey)?,
+    }
+}
+
+fn encode_rsa_public_pksc8_asn1(modulus: &[u8], exponent: &[u8]) -> Result<ASN1Block> {
+    let pksc1 = match simple_asn1::to_der(&encode_rsa_public_pksc1_asn1(modulus, exponent)) {
+        Ok(bytes) => bytes,
+        Err(_) => return Err(ErrorKind::InvalidRsaKey)?,
+    };
+    Ok(ASN1Block::Sequence(
+        0,
+        vec![
+            ASN1Block::Sequence(
+                0,
+                vec![
+                    // rsaEncryption (PKCS #1)
+                    ASN1Block::ObjectIdentifier(0, simple_asn1::oid!(1,2,840,113549,1,1,1)),
+                    ASN1Block::Null(0)
+                ]
+            ),
+            // the second parameter takes the count of bits
+            ASN1Block::BitString(0, pksc1.len() * 8, pksc1)
+        ],
+    ))
+}
+
+fn encode_rsa_public_pksc1_asn1(modulus: &[u8], exponent: &[u8]) -> ASN1Block {
+    ASN1Block::Sequence(
+        0,
+        vec![
+            ASN1Block::Integer(0, BigInt::from_signed_bytes_be(modulus)),
+            ASN1Block::Integer(0, BigInt::from_signed_bytes_be(exponent)),
+        ],
+    )
+}
+
+fn encode_ec_public_asn1(x: &[u8]) -> ASN1Block {
+    ASN1Block::Sequence(
+        0,
+        vec![
+            ASN1Block::Sequence(
+                0,
+                vec![
+                    // ecPublicKey (ANSI X9.62 public key type)
+                    ASN1Block::ObjectIdentifier(0, simple_asn1::oid!(1, 2, 840, 10045, 2, 1)),
+                    // prime256v1 (ANSI X9.62 named elliptic curve)
+                    ASN1Block::ObjectIdentifier(0, simple_asn1::oid!(1, 2, 840, 10045, 3, 1, 7)),
+                ],
+            ),
+            // the second parameter takes the count of bits
+            ASN1Block::BitString(0, x.len() * 8, x.to_vec()),
+        ],
+    )
+}

--- a/tests/ec/mod.rs
+++ b/tests/ec/mod.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
-use jsonwebtoken::{decode, decode_pem, encode, sign, verify, Algorithm, Header, Key, Validation};
+use jsonwebtoken::{decode, decode_pem, encode_ec_public_pem, encode_ec_public_der, encode, sign, verify, Algorithm, Header, Key, Validation};
 use serde::{Deserialize, Serialize};
+use ring::{signature, signature::KeyPair};
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Claims {
@@ -44,4 +45,31 @@ fn round_trip_claim() {
         decode::<Claims>(&token, Key::Pkcs8(pubkey), &Validation::new(Algorithm::ES256)).unwrap();
     assert_eq!(my_claims, token_data.claims);
     assert!(token_data.header.kid.is_none());
+}
+
+#[test]
+fn public_key_encoding() {
+    let privkey_pem = decode_pem(include_str!("private_ecdsa_key.pem")).unwrap();
+    let privkey = privkey_pem.as_key().unwrap();
+    let alg = &signature::ECDSA_P256_SHA256_FIXED_SIGNING;
+    let ring_key = signature::EcdsaKeyPair::from_pkcs8(alg, match privkey {
+        Key::Pkcs8(bytes) => bytes,
+        _ => panic!("Unexpected")
+    }).unwrap();
+
+    let public_key_pem = encode_ec_public_pem(ring_key.public_key().as_ref()).unwrap();
+    assert_eq!(include_str!("public_ecdsa_key.pem").trim(), public_key_pem.replace('\r', "").trim());
+
+    let public_key_der = encode_ec_public_der(ring_key.public_key().as_ref()).unwrap();
+    // The stored ".pk8" key is just the x coordinate of the EC key
+    // It's not truly a pkcs8 formatted DER
+    // To get around that, a prepended binary specifies the EC key, EC name,
+    // and X coordinate length. The length is unlikely to change.. in the
+    // event that it does, look at the pem file (convert base64 to hex) and find
+    // where 0x03, 0x42 don't match up. 0x42 is the length.
+    let mut stored_pk8_der = vec![0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2A, 0x86, 0x48,
+        0xCE, 0x3D, 0x02, 0x01, 0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01,
+        0x07, 0x03, 0x42, 0x00];
+    stored_pk8_der.extend(include_bytes!("public_ecdsa_key.pk8").to_vec());
+    assert_eq!(stored_pk8_der, public_key_der);
 }


### PR DESCRIPTION
It’s dirty and lacks documentation, tests probably can be relocated, but now a user of this library can make DER and PEMs of public key parameters