### PR TITLE
Use newest version of ring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 serde_json = "1.0"
 serde = {version = "1.0", features = ["derive"] }
-ring = { version = "0.16.5", features = ["std"] }
+ring = { version = "0.16.9", features = ["std"] }
 base64 = "0.11"
 # For PEM decoding
 pem = "0.7"


### PR DESCRIPTION
using version 0.16.9 of ring fixes the build for WebAssembly target of JsonWebToken.