### PR TITLE
Fix Broken chrono Example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ simple_asn1 = "0.4"
 [dev-dependencies]
 # For the custom chrono example
 chrono = "0.4"
+quickcheck = "0.9.2"
+quickcheck_macros = "0.9.1"
 
 [badges]
 maintenance = { status = "passively-maintained" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,6 @@ simple_asn1 = "0.4"
 [dev-dependencies]
 # For the custom chrono example
 chrono = "0.4"
-quickcheck = "0.9.2"
-quickcheck_macros = "0.9.1"
 
 [badges]
 maintenance = { status = "passively-maintained" }

--- a/examples/custom_chrono.rs
+++ b/examples/custom_chrono.rs
@@ -23,7 +23,7 @@ mod jwt_numeric_date {
     where
         S: Serializer,
     {
-        let timestamp = date.timestamp();
+        let timestamp = date.timestamp_nanos();
         serializer.serialize_i64(timestamp)
     }
 
@@ -32,9 +32,7 @@ mod jwt_numeric_date {
     where
         D: Deserializer<'de>,
     {
-        Utc.timestamp_opt(i64::deserialize(deserializer)?, 0)
-            .single() // If there are multiple or no valid DateTimes from timestamp, return None
-            .ok_or_else(|| serde::de::Error::custom("invalid Unix timestamp value"))
+        Ok(Utc.timestamp_nanos(i64::deserialize(deserializer)?))
     }
 
     #[cfg(test)]

--- a/examples/custom_chrono.rs
+++ b/examples/custom_chrono.rs
@@ -77,8 +77,11 @@ mod jwt_numeric_date {
             // A token with the expiry of i64::MAX + 1
             let overflow_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJDdXN0b20gRGF0ZVRpbWUgc2VyL2RlIiwiaWF0IjowLCJleHAiOjkyMjMzNzIwMzY4NTQ3NzYwMDB9.G2PKreA27U8_xOwuIeCYXacFYeR46f9FyENIZfCrvEc";
 
-            let decode_result =
-                decode::<Claims>(&overflow_token, SECRET.as_ref(), &Validation::default());
+            let decode_result = decode::<Claims>(
+                &overflow_token,
+                &DecodingKey::from_secret(SECRET.as_ref()),
+                &Validation::default(),
+            );
 
             assert!(decode_result.is_err());
         }


### PR DESCRIPTION
Hi,

the provided example for custom `chrono` headers (https://github.com/Keats/jsonwebtoken/blob/master/examples/custom_chrono.rs) does not work, if the `chrono` timestamp contains milliseconds. I discovered this when implementing a test property for myself that ensured, encoding and decoding results in the identity.

One if my failures looked like this:

```
[src/auth.rs:131] cookie = DeviceCookie { 
    sub: "\u{0}",                                                                    
    nonce: "\u{0}",                       
    exp: 2020-04-22T13:42:23.284112768Z,                                             
}                                    
[src/auth.rs:131] parsed = DeviceCookie {                                            
    sub: "\u{0}",                                                                    
    nonce: "\u{0}",                                                                  
    exp: 2020-04-22T13:42:23Z,     
}
```

As you can see, `cookie` (the identity) has milliseconds set but since the serializer in the example serializes only the timestamp to the second, the milliseconds get lost and the tokens are no longer the same.

I updated the example to use `Utc::timestamp_nanos` for serializing and deserializing. This solves the issue. I also added a slightly modified version of my test property to the example to ensure, that everythink works as intended.

I also fixed the existing tests since the example didn't compile and after fixing it and running `cargo test --example=custom_chrono`, the `round_trip` test fails:

```
test jwt_numeric_date::tests::round_trip ... FAILED
test jwt_numeric_date::tests::should_fail_on_invalid_timestamp ... ok
test jwt_numeric_date::tests::to_token_and_parse_equals_identity ... ok

failures:

---- jwt_numeric_date::tests::round_trip stdout ----
thread 'jwt_numeric_date::tests::round_trip' panicked at 'attempt to multiply with overflow', /home/me/.cargo/registry/src/github.com-1ecc6299db9ec823/chrono-0.4.11/src/naive/datetime.rs:342:21
```

Running the tests in release mode (`cargo test --release --example=custom_chrono`) works fine since the overflow checks are disabled for release builds.

Adding the following to `Cargo.toml` would solve the problem, too, but I don't know if you want this.

```toml
[profile.test]
overflow-checks = false
```

After disabling overflow checks for tests and running the test again, it fails with an assertion error:

```
thread 'jwt_numeric_date::tests::round_trip' panicked at 'assertion failed: `(left == right)`
  left: `"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJDdXN0b20gRGF0ZVRpbWUgc2VyL2RlIiwiaWF0IjowLCJleHAiOi00Mzg5ODA4MTQ3NDE5MTAzMjMyfQ.P2cnrIjFilrosSMBZeI5KaNDZxkxVir8l_cpvZbAP30"`,
 right: `"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJDdXN0b20gRGF0ZVRpbWUgc2VyL2RlIiwiaWF0IjowLCJleHAiOjMyNTAzNjgwMDAwfQ.RTgha0S53MjPC2pMA4e2oMzaBxSY3DMjiYR2qFfV55A"`', examples/custom_chrono.rs:63:13
```

I'm not quite sure, what to to with this test...