### PR TITLE
Decode RSA components only once

### DIFF
--- a/src/crypto/rsa.rs
+++ b/src/crypto/rsa.rs
@@ -1,5 +1,4 @@
 use ring::{rand, signature};
-use simple_asn1::BigUint;
 
 use crate::algorithms::Algorithm;
 use crate::errors::{ErrorKind, Result};
@@ -55,12 +54,13 @@ pub(crate) fn verify_from_components(
     alg: &'static signature::RsaParameters,
     signature: &str,
     message: &str,
-    components: (&str, &str),
+    components: (&[u8], &[u8]),
 ) -> Result<bool> {
     let signature_bytes = b64_decode(signature)?;
-    let n = BigUint::from_bytes_be(&b64_decode(components.0)?).to_bytes_be();
-    let e = BigUint::from_bytes_be(&b64_decode(components.1)?).to_bytes_be();
-    let pubkey = signature::RsaPublicKeyComponents { n, e };
+    let pubkey = signature::RsaPublicKeyComponents {
+        n: components.0,
+        e: components.1
+    };
     let res = pubkey.verify(alg, message.as_ref(), &signature_bytes);
     Ok(res.is_ok())
 }

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -46,6 +46,35 @@ pub struct DecodingKey<'a> {
 }
 
 impl DecodingKey<'static> {
+    /// If you're using HMAC with a base64 encoded, use this.
+    pub fn from_base64_secret(secret: &str) -> Result<Self> {
+        let out = base64::decode(&secret)?;
+        Ok(DecodingKey {
+            family: AlgorithmFamily::Hmac,
+            kind: DecodingKeyKind::SecretOrDer(Cow::Owned(out)),
+        })
+    }
+
+    /// If you have a ECDSA public key in PEM format, use this.
+    pub fn from_ec_pem(key: &[u8]) -> Result<Self> {
+        let pem_key = PemEncodedKey::new(key)?;
+        let content = pem_key.as_ec_public_key()?;
+        Ok(DecodingKey {
+            family: AlgorithmFamily::Ec,
+            kind: DecodingKeyKind::SecretOrDer(Cow::Owned(content.to_vec())),
+        })
+    }
+
+    /// If you are loading a public RSA key in a PEM format, use this.
+    pub fn from_rsa_pem(key: &[u8]) -> Result<Self> {
+        let pem_key = PemEncodedKey::new(key)?;
+        let content = pem_key.as_rsa_key()?;
+        Ok(DecodingKey {
+            family: AlgorithmFamily::Rsa,
+            kind: DecodingKeyKind::SecretOrDer(Cow::Owned(content.to_vec())),
+        })
+    }
+
     /// If you have (n, e) RSA public key components encoded in Base64, use this.
     pub fn from_rsa_components(modulus: &str, exponent: &str) -> Result<Self> {
         let n = b64_decode(modulus)?;
@@ -66,25 +95,6 @@ impl<'a> DecodingKey<'a> {
         }
     }
 
-    /// If you're using HMAC with a base64 encoded, use this.
-    pub fn from_base64_secret(secret: &str) -> Result<Self> {
-        let out = base64::decode(&secret)?;
-        Ok(DecodingKey {
-            family: AlgorithmFamily::Hmac,
-            kind: DecodingKeyKind::SecretOrDer(Cow::Owned(out)),
-        })
-    }
-
-    /// If you are loading a public RSA key in a PEM format, use this.
-    pub fn from_rsa_pem(key: &'a [u8]) -> Result<Self> {
-        let pem_key = PemEncodedKey::new(key)?;
-        let content = pem_key.as_rsa_key()?;
-        Ok(DecodingKey {
-            family: AlgorithmFamily::Rsa,
-            kind: DecodingKeyKind::SecretOrDer(Cow::Owned(content.to_vec())),
-        })
-    }
-
     /// If you have (n, e) RSA public key components, use this.
     pub fn from_rsa_raw_components(modulus: &'a [u8], exponent: &'a [u8]) -> Self {
         DecodingKey {
@@ -94,16 +104,6 @@ impl<'a> DecodingKey<'a> {
                 e: Cow::Borrowed(exponent),
              },
         }
-    }
-
-    /// If you have a ECDSA public key in PEM format, use this.
-    pub fn from_ec_pem(key: &'a [u8]) -> Result<Self> {
-        let pem_key = PemEncodedKey::new(key)?;
-        let content = pem_key.as_ec_public_key()?;
-        Ok(DecodingKey {
-            family: AlgorithmFamily::Ec,
-            kind: DecodingKeyKind::SecretOrDer(Cow::Owned(content.to_vec())),
-        })
     }
 
     /// If you know what you're doing and have a RSA DER encoded public key, use this.

--- a/tests/rsa/mod.rs
+++ b/tests/rsa/mod.rs
@@ -99,6 +99,7 @@ fn rsa_modulus_exponent() {
     };
     let n = "yRE6rHuNR0QbHO3H3Kt2pOKGVhQqGZXInOduQNxXzuKlvQTLUTv4l4sggh5_CYYi_cvI-SXVT9kPWSKXxJXBXd_4LkvcPuUakBoAkfh-eiFVMh2VrUyWyj3MFl0HTVF9KwRXLAcwkREiS3npThHRyIxuy0ZMeZfxVL5arMhw1SRELB8HoGfG_AtH89BIE9jDBHZ9dLelK9a184zAf8LwoPLxvJb3Il5nncqPcSfKDDodMFBIMc4lQzDKL5gvmiXLXB1AGLm8KBjfE8s3L5xqi-yUod-j8MtvIj812dkS4QMiRVN_by2h3ZY8LYVGrqZXZTcgn2ujn8uKjXLZVD5TdQ";
     let e = "AQAB";
+    let key = DecodingKey::from_rsa_components(n, e).unwrap();
 
     let encrypted = encode(
         &Header::new(Algorithm::RS256),
@@ -108,7 +109,7 @@ fn rsa_modulus_exponent() {
     .unwrap();
     let res = decode::<Claims>(
         &encrypted,
-        &DecodingKey::from_rsa_components(n, e),
+        &key,
         &Validation::new(Algorithm::RS256),
     );
     assert!(res.is_ok());


### PR DESCRIPTION
Instead of decoding the RSA modulus and exponent _every_ time that the
decoding key is required, do that once. This also ensures that any
errors with the exponent or modulus are identified early, rather than
on the first attempt to decode a token.

Note, this is a breaking change, as `from_rsa_components` can now fail
due to early validation of the modulus and exponent. Also, I've removed
the conversion through BigUInt, as performed significant work, and then
immediately undoes it. Leaving that out functions just as well.