### PR TITLE
Updating base64 to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 serde_json = "1.0"
 serde = {version = "1.0", features = ["derive"] }
 ring = { version = "0.16.5", features = ["std"] }
-base64 = "0.11"
+base64 = "0.12"
 # For PEM decoding
 pem = "0.7"
 simple_asn1 = "0.4"


### PR DESCRIPTION
Base64:
https://github.com/marshallpierce/rust-base64/compare/v0.11.0...v0.12.1
The commits show that its mostly new stuff, modularization and the switch to no_std
