### PR TITLE
Derive Hash for Header and Algorithm

### DIFF
--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -10,7 +10,7 @@ pub(crate) enum AlgorithmFamily {
 }
 
 /// The algorithms supported for signing/verifying JWTs
-#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Hash, Copy, Clone, Serialize, Deserialize)]
 pub enum Algorithm {
     /// HMAC using SHA-256
     HS256,

--- a/src/header.rs
+++ b/src/header.rs
@@ -6,7 +6,7 @@ use crate::serialization::b64_decode;
 
 /// A basic JWT header, the alg defaults to HS256 and typ is automatically
 /// set to `JWT`. All the other fields are optional.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Header {
     /// The type of JWS: it can only be "JWT" here
     ///


### PR DESCRIPTION
As discussed in #136, this will allow `Header` to be hashed. This also requires `Algorithm` to be hashable. 