### PR TITLE
Add dangerous_insecure_decode_with_validation

### DIFF
--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -206,6 +206,44 @@ pub fn dangerous_unsafe_decode<T: DeserializeOwned>(token: &str) -> Result<Token
     Ok(TokenData { header, claims: decoded_claims })
 }
 
+/// Decode and validate a JWT without any signature verification.
+///
+/// If the token is invalid or the claims fail validation, it will return an error.
+///
+/// NOTE: Do not use this unless you know what you are doing! If the token's signature is invalid, it will *not* return an error.
+///
+/// ```rust
+/// use serde::{Deserialize, Serialize};
+/// use jsonwebtoken::{dangerous_insecure_decode_with_validation, Validation, Algorithm};
+///
+/// #[derive(Debug, Serialize, Deserialize)]
+/// struct Claims {
+///    sub: String,
+///    company: String
+/// }
+///
+/// let token = "a.jwt.token";
+/// // Claims is a struct that implements Deserialize
+/// let token_message = dangerous_insecure_decode_with_validation::<Claims>(&token, &Validation::new(Algorithm::HS256));
+/// ```
+pub fn dangerous_insecure_decode_with_validation<T: DeserializeOwned>(
+    token: &str,
+    validation: &Validation,
+) -> Result<TokenData<T>> {
+    let (_, message) = expect_two!(token.rsplitn(2, '.'));
+    let (claims, header) = expect_two!(message.rsplitn(2, '.'));
+    let header = Header::from_encoded(header)?;
+
+    if !validation.algorithms.contains(&header.alg) {
+        return Err(new_error(ErrorKind::InvalidAlgorithm));
+    }
+
+    let (decoded_claims, claims_map): (T, _) = from_jwt_part_claims(claims)?;
+    validate(&claims_map, validation)?;
+
+    Ok(TokenData { header, claims: decoded_claims })
+}
+
 /// Decode a JWT without any signature verification/validations and return its [Header](struct.Header.html).
 ///
 /// If the token has an invalid format (ie 3 parts separated by a `.`), it will return an error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,10 @@ mod serialization;
 mod validation;
 
 pub use algorithms::Algorithm;
-pub use decoding::{dangerous_unsafe_decode, decode, decode_header, DecodingKey, TokenData};
+pub use decoding::{
+    dangerous_insecure_decode_with_validation, dangerous_unsafe_decode, decode, decode_header,
+    DecodingKey, TokenData,
+};
 pub use encoding::{encode, EncodingKey};
 pub use header::Header;
 pub use validation::Validation;

--- a/tests/hmac.rs
+++ b/tests/hmac.rs
@@ -1,4 +1,5 @@
 use chrono::Utc;
+use jsonwebtoken::dangerous_insecure_decode_with_validation;
 use jsonwebtoken::{
     crypto::{sign, verify},
     dangerous_unsafe_decode, decode, decode_header, encode, Algorithm, DecodingKey, EncodingKey,
@@ -156,5 +157,35 @@ fn dangerous_unsafe_decode_token_invalid_signature() {
 fn dangerous_unsafe_decode_token_wrong_algorithm() {
     let token = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUiLCJleHAiOjI1MzI1MjQ4OTF9.fLxey-hxAKX5rNHHIx1_Ch0KmrbiuoakDVbsJjLWrx8fbjKjrPuWMYEJzTU3SBnYgnZokC-wqSdqckXUOunC-g";
     let claims = dangerous_unsafe_decode::<Claims>(token);
+    claims.unwrap();
+}
+
+#[test]
+fn dangerous_insecure_decode_token_with_validation() {
+    let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUiLCJleHAiOjI1MzI1MjQ4OTF9.9r56oF7ZliOBlOAyiOFperTGxBtPykRQiWNFxhDCW98";
+    let claims = dangerous_insecure_decode_with_validation::<Claims>(token, &Validation::default());
+    claims.unwrap();
+}
+
+#[test]
+#[should_panic(expected = "InvalidToken")]
+fn dangerous_insecure_decode_token_with_validation_missing_parts() {
+    let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+    let claims = dangerous_insecure_decode_with_validation::<Claims>(token, &Validation::default());
+    claims.unwrap();
+}
+
+#[test]
+fn dangerous_insecure_decode_token_with_validation_invalid_signature() {
+    let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUiLCJleHAiOjI1MzI1MjQ4OTF9.wrong";
+    let claims = dangerous_insecure_decode_with_validation::<Claims>(token, &Validation::default());
+    claims.unwrap();
+}
+
+#[test]
+#[should_panic(expected = "InvalidAlgorithm")]
+fn dangerous_insecure_decode_token_with_validation_wrong_algorithm() {
+    let token = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUiLCJleHAiOjI1MzI1MjQ4OTF9.fLxey-hxAKX5rNHHIx1_Ch0KmrbiuoakDVbsJjLWrx8fbjKjrPuWMYEJzTU3SBnYgnZokC-wqSdqckXUOunC-g";
+    let claims = dangerous_insecure_decode_with_validation::<Claims>(token, &Validation::default());
     claims.unwrap();
 }


### PR DESCRIPTION
Discussed in #135.
Adds a new function `dangerous_insecure_decode_with_validation`, which is a middle-ground between `decode` and `dangerous_unsafe_decode`. It takes a `Validation` and uses the `validate` function to run validations, but it does not do any signature verification.

I added the same set of tests that `decode` and `dangerous_unsafe_decode` have:
1. Regular
2. Invalid token
3. Invalid signature
4. Invalid algorithm

The new function passes numbers 1 and 3, but fails for numbers 2 and 4.

Note: the tests appear to be failing due to compiling the latest version of `base64` (v0.12.2) on Rust 1.39.0.