### PR TITLE
Rename dangerous_unsafe_decode to dangerous_insecure_decode

### DIFF
--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -184,7 +184,7 @@ pub fn decode<T: DeserializeOwned>(
 ///
 /// ```rust
 /// use serde::{Deserialize, Serialize};
-/// use jsonwebtoken::{dangerous_unsafe_decode, Validation, Algorithm};
+/// use jsonwebtoken::{dangerous_insecure_decode, Validation, Algorithm};
 ///
 /// #[derive(Debug, Serialize, Deserialize)]
 /// struct Claims {
@@ -194,9 +194,9 @@ pub fn decode<T: DeserializeOwned>(
 ///
 /// let token = "a.jwt.token".to_string();
 /// // Claims is a struct that implements Deserialize
-/// let token_message = dangerous_unsafe_decode::<Claims>(&token);
+/// let token_message = dangerous_insecure_decode::<Claims>(&token);
 /// ```
-pub fn dangerous_unsafe_decode<T: DeserializeOwned>(token: &str) -> Result<TokenData<T>> {
+pub fn dangerous_insecure_decode<T: DeserializeOwned>(token: &str) -> Result<TokenData<T>> {
     let (_, message) = expect_two!(token.rsplitn(2, '.'));
     let (claims, header) = expect_two!(message.rsplitn(2, '.'));
     let header = Header::from_encoded(header)?;

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -206,6 +206,31 @@ pub fn dangerous_insecure_decode<T: DeserializeOwned>(token: &str) -> Result<Tok
     Ok(TokenData { header, claims: decoded_claims })
 }
 
+/// Decode a JWT without any signature verification/validations.
+///
+/// NOTE: Do not use this unless you know what you are doing! If the token's signature is invalid, it will *not* return an error.
+///
+/// ```rust
+/// use serde::{Deserialize, Serialize};
+/// use jsonwebtoken::{dangerous_unsafe_decode, Validation, Algorithm};
+///
+/// #[derive(Debug, Serialize, Deserialize)]
+/// struct Claims {
+///     sub: String,
+///     company: String
+/// }
+///
+/// let token = "a.jwt.token".to_string();
+/// // Claims is a struct that implements Deserialize
+/// let token_message = dangerous_unsafe_decode::<Claims>(&token);
+/// ```
+#[deprecated(
+    note = "This function has been renamed to `dangerous_unsafe_decode` and will be removed in a later version."
+)]
+pub fn dangerous_unsafe_decode<T: DeserializeOwned>(token: &str) -> Result<TokenData<T>> {
+    dangerous_insecure_decode(token)
+}
+
 /// Decode a JWT without any signature verification/validations and return its [Header](struct.Header.html).
 ///
 /// If the token has an invalid format (ie 3 parts separated by a `.`), it will return an error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,10 @@ mod serialization;
 mod validation;
 
 pub use algorithms::Algorithm;
-pub use decoding::{dangerous_insecure_decode, decode, decode_header, DecodingKey, TokenData};
+pub use decoding::{
+    dangerous_insecure_decode, dangerous_unsafe_decode, decode, decode_header, DecodingKey,
+    TokenData,
+};
 pub use encoding::{encode, EncodingKey};
 pub use header::Header;
 pub use validation::Validation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ mod serialization;
 mod validation;
 
 pub use algorithms::Algorithm;
-pub use decoding::{dangerous_unsafe_decode, decode, decode_header, DecodingKey, TokenData};
+pub use decoding::{dangerous_insecure_decode, decode, decode_header, DecodingKey, TokenData};
 pub use encoding::{encode, EncodingKey};
 pub use header::Header;
 pub use validation::Validation;

--- a/tests/hmac.rs
+++ b/tests/hmac.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use jsonwebtoken::{
     crypto::{sign, verify},
-    dangerous_unsafe_decode, decode, decode_header, encode, Algorithm, DecodingKey, EncodingKey,
+    dangerous_insecure_decode, decode, decode_header, encode, Algorithm, DecodingKey, EncodingKey,
     Header, Validation,
 };
 use serde::{Deserialize, Serialize};
@@ -131,30 +131,30 @@ fn decode_header_only() {
 }
 
 #[test]
-fn dangerous_unsafe_decode_token() {
+fn dangerous_insecure_decode_token() {
     let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUiLCJleHAiOjI1MzI1MjQ4OTF9.9r56oF7ZliOBlOAyiOFperTGxBtPykRQiWNFxhDCW98";
-    let claims = dangerous_unsafe_decode::<Claims>(token);
+    let claims = dangerous_insecure_decode::<Claims>(token);
     claims.unwrap();
 }
 
 #[test]
 #[should_panic(expected = "InvalidToken")]
-fn dangerous_unsafe_decode_token_missing_parts() {
+fn dangerous_insecure_decode_token_missing_parts() {
     let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
-    let claims = dangerous_unsafe_decode::<Claims>(token);
+    let claims = dangerous_insecure_decode::<Claims>(token);
     claims.unwrap();
 }
 
 #[test]
-fn dangerous_unsafe_decode_token_invalid_signature() {
+fn dangerous_insecure_decode_token_invalid_signature() {
     let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUiLCJleHAiOjI1MzI1MjQ4OTF9.wrong";
-    let claims = dangerous_unsafe_decode::<Claims>(token);
+    let claims = dangerous_insecure_decode::<Claims>(token);
     claims.unwrap();
 }
 
 #[test]
-fn dangerous_unsafe_decode_token_wrong_algorithm() {
+fn dangerous_insecure_decode_token_wrong_algorithm() {
     let token = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUiLCJleHAiOjI1MzI1MjQ4OTF9.fLxey-hxAKX5rNHHIx1_Ch0KmrbiuoakDVbsJjLWrx8fbjKjrPuWMYEJzTU3SBnYgnZokC-wqSdqckXUOunC-g";
-    let claims = dangerous_unsafe_decode::<Claims>(token);
+    let claims = dangerous_insecure_decode::<Claims>(token);
     claims.unwrap();
 }


### PR DESCRIPTION
As suggested in #130, renames `dangerous_unsafe_decode` to `dangerous_insecure_decode`. This is because "unsafe" has a very specific meaning in Rust, and this function is _not_ and `unsafe` function.

Note that this would be a breaking change and therefore require a major version bump.