### PR TITLE
Bump minimum required Rust version to 1.40.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-18.04
-          rust: 1.39.0
+          rust: 1.40.0
         - build: stable
           os: ubuntu-18.04
           rust: stable

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ jsonwebtoken = "7"
 serde = {version = "1.0", features = ["derive"] }
 ```
 
-The minimum required Rust version is 1.39.
+The minimum required Rust version is 1.40.
 
 ## Algorithms
 This library currently supports the following:


### PR DESCRIPTION
Motivation for this change is use of `#[non_exhaustive]` attribute that was stabilized in Rust 1.40.0