### PR TITLE
Support more header parameters

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -46,6 +46,9 @@ pub enum ErrorKind {
     InvalidAlgorithmName,
     /// When a key is provided with an invalid format
     InvalidKeyFormat,
+    /// When a JWT crit header is empty, includes a name not present as a key in the header, or
+    /// includes a name for a parameter specified in JWS (RFC 7515) or JWA (RFC 7518)
+    InvalidCriticalHeader,
 
     // Validation errors
     /// When a token’s `exp` claim indicates that it has expired
@@ -88,6 +91,7 @@ impl StdError for Error {
             ErrorKind::InvalidAlgorithm => None,
             ErrorKind::InvalidAlgorithmName => None,
             ErrorKind::InvalidKeyFormat => None,
+            ErrorKind::InvalidCriticalHeader => None,
             ErrorKind::Base64(ref err) => Some(err),
             ErrorKind::Json(ref err) => Some(err),
             ErrorKind::Utf8(ref err) => Some(err),
@@ -110,6 +114,7 @@ impl fmt::Display for Error {
             | ErrorKind::ImmatureSignature
             | ErrorKind::InvalidAlgorithm
             | ErrorKind::InvalidKeyFormat
+            | ErrorKind::InvalidCriticalHeader
             | ErrorKind::InvalidAlgorithmName => write!(f, "{:?}", self.0),
             ErrorKind::Json(ref err) => write!(f, "JSON error: {}", err),
             ErrorKind::Utf8(ref err) => write!(f, "UTF-8 error: {}", err),

--- a/src/header.rs
+++ b/src/header.rs
@@ -42,6 +42,12 @@ pub struct Header {
     /// Defined in [RFC7515#4.1.7](https://tools.ietf.org/html/rfc7515#section-4.1.7).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub x5t: Option<String>,
+    /// X.509 certificate SHA-256 thumbprint
+    ///
+    /// Defined in [RFC7515#4.1.7](https://tools.ietf.org/html/rfc7515#section-4.1.8).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x5t#S256")]
+    pub x5t_s256: Option<String>,
     /// Critical
     ///
     /// Defined in [RFC7515#4.1.11](https://tools.ietf.org/html/rfc7515#section-4.1.11).
@@ -64,6 +70,7 @@ impl Header {
             kid: None,
             x5u: None,
             x5t: None,
+            x5t_s256: None,
             crit: None,
             params: None,
         }

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::algorithms::Algorithm;
-use crate::errors::Result;
+use crate::errors::{new_error, ErrorKind, Result};
 use crate::serialization::b64_decode;
 
 /// A basic JWT header, the alg defaults to HS256 and typ is automatically
@@ -42,6 +42,11 @@ pub struct Header {
     /// Defined in [RFC7515#4.1.7](https://tools.ietf.org/html/rfc7515#section-4.1.7).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub x5t: Option<String>,
+    /// Critical
+    ///
+    /// Defined in [RFC7515#4.1.11](https://tools.ietf.org/html/rfc7515#section-4.1.11).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub crit: Option<Vec<String>>,
     /// Additional Public or Private header parameters
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(flatten)]
@@ -59,6 +64,7 @@ impl Header {
             kid: None,
             x5u: None,
             x5t: None,
+            crit: None,
             params: None,
         }
     }
@@ -67,8 +73,30 @@ impl Header {
     pub(crate) fn from_encoded(encoded_part: &str) -> Result<Self> {
         let decoded = b64_decode(encoded_part)?;
         let s = String::from_utf8(decoded)?;
+        let header: Header = serde_json::from_str(&s)?;
 
-        Ok(serde_json::from_str(&s)?)
+        if let Some(crit) = &header.crit {
+            if crit.is_empty() {
+                return Err(new_error(ErrorKind::InvalidCriticalHeader));
+            }
+            for name in crit {
+                match name.as_str() {
+                    "alg" | "jku" | "jwk" | "kid" | "x5u" | "x5c" | "x5t" | "x5t#S256" | "typ"
+                    | "cty" | "crit" => return Err(new_error(ErrorKind::InvalidCriticalHeader)),
+                    _ => {
+                        let has = match &header.params {
+                            Some(params) => params.contains_key(name),
+                            None => false,
+                        };
+                        if !has {
+                            return Err(new_error(ErrorKind::InvalidCriticalHeader));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(header)
     }
 }
 
@@ -94,5 +122,49 @@ mod tests {
         let res = Header::from_encoded(&header_b64);
         let header = res.unwrap();
         assert_eq!(header.params.unwrap().get("example").unwrap(), 123);
+    }
+
+    #[test]
+    fn crit_invalid_fails() {
+        let header_json = r###"{
+            "alg": "ES256",
+            "crit": ["alg"]
+        }"###;
+        let header_b64 = base64::encode_config(header_json, base64::URL_SAFE_NO_PAD);
+        let res = Header::from_encoded(&header_b64);
+        assert!(res.is_err());
+
+        match res.unwrap_err().kind() {
+            ErrorKind::InvalidCriticalHeader => (),
+            _ => unreachable!(),
+        };
+    }
+
+    #[test]
+    fn crit_missing_fails() {
+        let header_json = r###"{
+            "alg": "ES256",
+            "crit": ["b64"]
+        }"###;
+        let header_b64 = base64::encode_config(header_json, base64::URL_SAFE_NO_PAD);
+        let res = Header::from_encoded(&header_b64);
+        assert!(res.is_err());
+
+        match res.unwrap_err().kind() {
+            ErrorKind::InvalidCriticalHeader => (),
+            _ => unreachable!(),
+        };
+    }
+
+    #[test]
+    fn crit_present_ok() {
+        let header_json = r###"{
+            "alg": "ES256",
+            "crit": ["b64"],
+            "b64": false
+        }"###;
+        let header_b64 = base64::encode_config(header_json, base64::URL_SAFE_NO_PAD);
+        let res = Header::from_encoded(&header_b64);
+        assert!(res.is_ok());
     }
 }


### PR DESCRIPTION
This adds support for the `crit` header parameter (RFC 7515), and additional header parameters via a `params` map.

I added logic for the `crit` header to check for invalid uses. Applications must do additional checking of `crit` to ensure they can understand any listed parameters.

To make the `params` map work, I removed `Hash` from the `derive` attribute of the `Header` struct. If this is a problem, I could try to find an alternative solution.

I added tests for the `crit` parameter checking and to show use of the `params` map flattened into the header struct.