### PR TITLE
Add sign and verify on bytes

### DIFF
--- a/src/crypto/ecdsa.rs
+++ b/src/crypto/ecdsa.rs
@@ -29,10 +29,10 @@ pub(crate) fn alg_to_ec_signing(alg: Algorithm) -> &'static signature::EcdsaSign
 pub fn sign(
     alg: &'static signature::EcdsaSigningAlgorithm,
     key: &[u8],
-    message: &str,
+    message: &[u8],
 ) -> Result<String> {
     let signing_key = signature::EcdsaKeyPair::from_pkcs8(alg, key)?;
     let rng = rand::SystemRandom::new();
-    let out = signing_key.sign(&rng, message.as_bytes())?;
+    let out = signing_key.sign(&rng, message)?;
     Ok(b64_encode(out.as_ref()))
 }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -12,8 +12,8 @@ pub(crate) mod rsa;
 
 /// The actual HS signing + encoding
 /// Could be in its own file to match RSA/EC but it's 2 lines...
-pub(crate) fn sign_hmac(alg: hmac::Algorithm, key: &[u8], message: &str) -> Result<String> {
-    let digest = hmac::sign(&hmac::Key::new(alg, key), message.as_bytes());
+pub(crate) fn sign_hmac(alg: hmac::Algorithm, key: &[u8], message: &[u8]) -> Result<String> {
+    let digest = hmac::sign(&hmac::Key::new(alg, key), message);
     Ok(b64_encode(digest.as_ref()))
 }
 
@@ -22,6 +22,11 @@ pub(crate) fn sign_hmac(alg: hmac::Algorithm, key: &[u8], message: &str) -> Resu
 ///
 /// If you just want to encode a JWT, use `encode` instead.
 pub fn sign(message: &str, key: &EncodingKey, algorithm: Algorithm) -> Result<String> {
+    sign_bytes(message.as_bytes(), key, algorithm)
+}
+
+/// Same as sign() but for message as bytes
+pub fn sign_bytes(message: &[u8], key: &EncodingKey, algorithm: Algorithm) -> Result<String> {
     match algorithm {
         Algorithm::HS256 => sign_hmac(hmac::HMAC_SHA256, key.inner(), message),
         Algorithm::HS384 => sign_hmac(hmac::HMAC_SHA384, key.inner(), message),
@@ -44,12 +49,12 @@ pub fn sign(message: &str, key: &EncodingKey, algorithm: Algorithm) -> Result<St
 fn verify_ring(
     alg: &'static dyn signature::VerificationAlgorithm,
     signature: &str,
-    message: &str,
+    message: &[u8],
     key: &[u8],
 ) -> Result<bool> {
     let signature_bytes = b64_decode(signature)?;
     let public_key = signature::UnparsedPublicKey::new(alg, key);
-    let res = public_key.verify(message.as_bytes(), &signature_bytes);
+    let res = public_key.verify(message, &signature_bytes);
 
     Ok(res.is_ok())
 }
@@ -68,10 +73,20 @@ pub fn verify(
     key: &DecodingKey,
     algorithm: Algorithm,
 ) -> Result<bool> {
+    Ok(verify_bytes(signature, message.as_bytes(), key, algorithm)?)
+}
+
+/// Same as verify() but for message as bytes
+pub fn verify_bytes(
+    signature: &str,
+    message: &[u8],
+    key: &DecodingKey,
+    algorithm: Algorithm,
+) -> Result<bool> {
     match algorithm {
         Algorithm::HS256 | Algorithm::HS384 | Algorithm::HS512 => {
             // we just re-sign the message with the key and compare if they are equal
-            let signed = sign(message, &EncodingKey::from_secret(key.as_bytes()), algorithm)?;
+            let signed = sign_bytes(message, &EncodingKey::from_secret(key.as_bytes()), algorithm)?;
             Ok(verify_slices_are_equal(signature.as_ref(), signed.as_ref()).is_ok())
         }
         Algorithm::ES256 | Algorithm::ES384 => verify_ring(


### PR DESCRIPTION
Re: https://github.com/Keats/jsonwebtoken/pull/148#issuecomment-689074489

This adds `sign_bytes` and `verify_bytes` functions in `crypto`, corresponding to the existing public `sign` and `verify` functions but accepting a message as bytes instead of as a string. The existing `sign` and `verify` functions are changed to be implemented in terms of the new `sign_bytes` and `verify_bytes` functions.

I changed the internal sign/verify functions to use bytes instead of strings rather than adding new functions there too, since those functions are not exported.

Signing and verifying messages as bytes instead of (base64url-encoded) strings is needed for the Unencoded Payload Option (#149).