### PR TITLE
add verify_sig fn

### DIFF
--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -135,7 +135,7 @@ impl<'a> DecodingKey<'a> {
 ///
 /// If the token or its signature is invalid, it will return an error.
 ///
-/// ```rust/// 
+/// ```rust///
 /// use jsonwebtoken::{verify_sig, DecodingKey, Validation, Algorithm};
 ///
 ///
@@ -145,7 +145,7 @@ impl<'a> DecodingKey<'a> {
 pub fn verify_sig(
     token: &str,
     key: &DecodingKey,
-    validation: &Validation
+    validation: &Validation,
 ) -> Result<(Header, String)> {
     for alg in &validation.algorithms {
         if key.family != alg.family() {
@@ -196,8 +196,8 @@ pub fn decode<T: DeserializeOwned>(
         Ok((header, claims)) => {
             let (decoded_claims, claims_map): (T, _) = from_jwt_part_claims(claims)?;
             validate(&claims_map, validation)?;
-        
-            Ok(TokenData { header, claims: decoded_claims })        
+
+            Ok(TokenData { header, claims: decoded_claims })
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub use algorithms::Algorithm;
 #[allow(deprecated)]
 pub use decoding::dangerous_unsafe_decode;
 pub use decoding::{
-    dangerous_insecure_decode, dangerous_insecure_decode_with_validation, decode, decode_header, 
+    dangerous_insecure_decode, dangerous_insecure_decode_with_validation, decode, decode_header,
     verify_sig, DecodingKey, TokenData,
 };
 pub use encoding::{encode, EncodingKey};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@ pub use algorithms::Algorithm;
 #[allow(deprecated)]
 pub use decoding::dangerous_unsafe_decode;
 pub use decoding::{
-    dangerous_insecure_decode, dangerous_insecure_decode_with_validation, decode, decode_header,
-    DecodingKey, TokenData,
+    dangerous_insecure_decode, dangerous_insecure_decode_with_validation, decode, decode_header, 
+    verify_sig, DecodingKey, TokenData,
 };
 pub use encoding::{encode, EncodingKey};
 pub use header::Header;


### PR DESCRIPTION
For #156. I'm essentially just pulling the signature verification steps into their own function that can be called independently, and then having `decode` call that new function rather than duplicating everything. I'm certainly not set on `verify_sig` as a function name, if you have suggestions.