### PR TITLE
Remove lifetime requirements for rsa pem keys.

### DIFF
--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -64,7 +64,7 @@ impl<'a> DecodingKey<'a> {
     }
 
     /// If you are loading a public RSA key in a PEM format, use this.
-    pub fn from_rsa_pem(key: &'a [u8]) -> Result<Self> {
+    pub fn from_rsa_pem(key: &[u8]) -> Result<Self> {
         let pem_key = PemEncodedKey::new(key)?;
         let content = pem_key.as_rsa_key()?;
         Ok(DecodingKey {


### PR DESCRIPTION
This lifetime requirement is not actually needed since the passed data is never held on to.

Furthermore, this specific requirements makes using the library to validate Firebase Auth tokens particularly painful. The keys need to be refreshed periodically, and managing the lifetime of the source data alongside the matching pre-compiled `DecodingKey` is a pain.