### PR TITLE
Update ring to 0.16.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 [dependencies]
 serde_json = "1.0"
 serde = {version = "1.0", features = ["derive"] }
-ring = { version = "0.16.5", features = ["std"] }
+ring = { version = "0.16.9", features = ["std"] }
 base64 = "0.12"
 # For PEM decoding
 pem = "0.8"


### PR DESCRIPTION
Allow crates that depend on jsonwebtoken to compile successfully on Apple Silicon (aarch64-apple-darwin).