### PR TITLE
Makes Algorithm traits available for library clients

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@
 //! Documentation:  [stable](https://docs.rs/jsonwebtoken/)
 #![deny(missing_docs)]
 
-mod algorithms;
+/// [std::str::FromStr] and [Default] implementations for [Algorithm]
+pub mod algorithms;
 /// Lower level functions, if you want to do something other than JWTs
 pub mod crypto;
 mod decoding;


### PR DESCRIPTION
The FromStr implementation for Algorithm is useful when clients of the
library are dealing with keys not provided at compile time (e.g. keys
retrieved from OIDC). Making the algorithm module public exposes the
FromStr and the Display traits for clients. This change is backward
compatible.