### PR TITLE
Bump dependencies (base64, simple_asn1), clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 serde_json = "1.0"
 serde = {version = "1.0", features = ["derive"] }
 ring = { version = "0.16.5", features = ["std"] }
-base64 = "0.12"
+base64 = "0.13"
 # For PEM decoding
 pem = "0.8"
-simple_asn1 = "0.4"
+simple_asn1 = "0.5"
 
 [dev-dependencies]
 # For the custom chrono example

--- a/examples/custom_header.rs
+++ b/examples/custom_header.rs
@@ -15,9 +15,8 @@ fn main() {
         Claims { sub: "b@b.com".to_owned(), company: "ACME".to_owned(), exp: 10000000000 };
     let key = b"secret";
 
-    let mut header = Header::default();
-    header.kid = Some("signing_key".to_owned());
-    header.alg = Algorithm::HS512;
+    let header =
+        Header { kid: Some("signing_key".to_owned()), alg: Algorithm::HS512, ..Default::default() };
 
     let token = match encode(&header, &my_claims, &EncodingKey::from_secret(key)) {
         Ok(t) => t,

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -12,9 +12,9 @@ pub(crate) mod rsa;
 
 /// The actual HS signing + encoding
 /// Could be in its own file to match RSA/EC but it's 2 lines...
-pub(crate) fn sign_hmac(alg: hmac::Algorithm, key: &[u8], message: &str) -> Result<String> {
+pub(crate) fn sign_hmac(alg: hmac::Algorithm, key: &[u8], message: &str) -> String {
     let digest = hmac::sign(&hmac::Key::new(alg, key), message.as_bytes());
-    Ok(b64_encode(digest.as_ref()))
+    b64_encode(digest.as_ref())
 }
 
 /// Take the payload of a JWT, sign it using the algorithm given and return
@@ -23,9 +23,9 @@ pub(crate) fn sign_hmac(alg: hmac::Algorithm, key: &[u8], message: &str) -> Resu
 /// If you just want to encode a JWT, use `encode` instead.
 pub fn sign(message: &str, key: &EncodingKey, algorithm: Algorithm) -> Result<String> {
     match algorithm {
-        Algorithm::HS256 => sign_hmac(hmac::HMAC_SHA256, key.inner(), message),
-        Algorithm::HS384 => sign_hmac(hmac::HMAC_SHA384, key.inner(), message),
-        Algorithm::HS512 => sign_hmac(hmac::HMAC_SHA512, key.inner(), message),
+        Algorithm::HS256 => Ok(sign_hmac(hmac::HMAC_SHA256, key.inner(), message)),
+        Algorithm::HS384 => Ok(sign_hmac(hmac::HMAC_SHA384, key.inner(), message)),
+        Algorithm::HS512 => Ok(sign_hmac(hmac::HMAC_SHA512, key.inner(), message)),
 
         Algorithm::ES256 | Algorithm::ES384 => {
             ecdsa::sign(ecdsa::alg_to_ec_signing(algorithm), key.inner(), message)

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -69,9 +69,7 @@ pub struct Validation {
 impl Validation {
     /// Create a default validation setup allowing the given alg
     pub fn new(alg: Algorithm) -> Validation {
-        let mut validation = Validation::default();
-        validation.algorithms = vec![alg];
-        validation
+        Validation { algorithms: vec![alg], ..Default::default() }
     }
 
     /// `aud` is a collection of one or more acceptable audience members

--- a/tests/hmac.rs
+++ b/tests/hmac.rs
@@ -37,8 +37,7 @@ fn encode_with_custom_header() {
         company: "ACME".to_string(),
         exp: Utc::now().timestamp() + 10000,
     };
-    let mut header = Header::default();
-    header.kid = Some("kid".to_string());
+    let header = Header { kid: Some("kid".to_string()), ..Default::default() };
     let token = encode(&header, &my_claims, &EncodingKey::from_secret(b"secret")).unwrap();
     let token_data =
         decode::<Claims>(&token, &DecodingKey::from_secret(b"secret"), &Validation::default())


### PR DESCRIPTION
My project uses your library, thank you for writing it, it's very useful. I was going through my project, cleaning up old dependencies and looking for any projects that pulled in different versions, and upgrading them to the newer version where possible. Seems like these version bumps don't involve any breaking changes, as your library still compiles and passes its tests after bumping the version. So I went ahead and opened this PR. 

I initially just wanted to upgrade the dependencies. But then I noticed CI was failing due to the new Clippy lints in new Rust releases, so I fixed those too. 

It'd be great if you could cut a new v7.2.1 release after merging this! That way I wouldn't need to wait for the v8 you're working on to be finished. Thank you for your time.