### PR TITLE
Multiple iss field validation check

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ struct Validation {
     pub validate_exp: bool,             // Default: true
     pub validate_nbf: bool,             // Default: false
     pub aud: Option<HashSet<String>>,   // Default: None
-    pub iss: Option<String>,            // Default: None
+    pub iss: Option<HashSet<String>>,   // Default: None
     pub sub: Option<String>,            // Default: None
     pub algorithms: Vec<Algorithm>,     // Default: vec![Algorithm::HS256]
 }
@@ -185,7 +185,9 @@ let validation = Validation::new(Algorithm::HS512);
 // Adding some leeway (in seconds) for exp and nbf checks
 let mut validation = Validation {leeway: 60, ..Default::default()};
 // Checking issuer
-let mut validation = Validation {iss: Some("issuer".to_string()), ..Default::default()};
+let mut iss = std::collections::HashSet::new();
+iss.insert("issuer".to_string());
+let mut validation = Validation {iss: Some(iss), ..Default::default()};
 // Setting audience
 let mut validation = Validation::default();
 validation.set_audience(&"Me"); // string

--- a/examples/custom_header.rs
+++ b/examples/custom_header.rs
@@ -10,6 +10,7 @@ struct Claims {
     exp: usize,
 }
 
+#[allow(clippy::field_reassign_with_default)]
 fn main() {
     let my_claims =
         Claims { sub: "b@b.com".to_owned(), company: "ACME".to_owned(), exp: 10000000000 };

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod rsa;
 
 /// The actual HS signing + encoding
 /// Could be in its own file to match RSA/EC but it's 2 lines...
+#[allow(clippy::unnecessary_wraps)]
 pub(crate) fn sign_hmac(alg: hmac::Algorithm, key: &[u8], message: &str) -> Result<String> {
     let digest = hmac::sign(&hmac::Key::new(alg, key), message.as_bytes());
     Ok(b64_encode(digest.as_ref()))

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -139,12 +139,8 @@ pub fn validate(claims: &Map<String, Value>, options: &Validation) -> Result<()>
     }
 
     if let Some(ref correct_iss) = options.iss {
-        if let Some(iss) = claims.get("iss") {
-            if let Value::String(iss) = iss {
-                if !correct_iss.contains(iss) {
-                    return Err(new_error(ErrorKind::InvalidIssuer));
-                }
-            } else {
+        if let Some(Value::String(iss)) = claims.get("iss") {
+            if !correct_iss.contains(iss) {
                 return Err(new_error(ErrorKind::InvalidIssuer));
             }
         } else {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -78,6 +78,11 @@ impl Validation {
     pub fn set_audience<T: ToString>(&mut self, items: &[T]) {
         self.aud = Some(items.iter().map(|x| x.to_string()).collect())
     }
+
+    /// `iss` is a collection of one or more acceptable iss members
+    pub fn set_iss<T: ToString>(&mut self, items: &[T]) {
+        self.iss = Some(items.iter().map(|x| x.to_string()).collect())
+    }
 }
 
 impl Default for Validation {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -49,11 +49,11 @@ pub struct Validation {
     ///
     /// Defaults to `None`.
     pub aud: Option<HashSet<String>>,
-    /// If it contains a value, the validation will check that the `iss` field is the same as the
-    /// one provided and will error otherwise.
+    /// If it contains a value, the validation will check that the `iss` field is a member of the
+    /// iss provided and will error otherwise.
     ///
     /// Defaults to `None`.
-    pub iss: Option<String>,
+    pub iss: Option<HashSet<String>>,
     /// If it contains a value, the validation will check that the `sub` field is the same as the
     /// one provided and will error otherwise.
     ///
@@ -125,16 +125,6 @@ pub fn validate(claims: &Map<String, Value>, options: &Validation) -> Result<()>
         }
     }
 
-    if let Some(ref correct_iss) = options.iss {
-        if let Some(iss) = claims.get("iss") {
-            if from_value::<String>(iss.clone())? != *correct_iss {
-                return Err(new_error(ErrorKind::InvalidIssuer));
-            }
-        } else {
-            return Err(new_error(ErrorKind::InvalidIssuer));
-        }
-    }
-
     if let Some(ref correct_sub) = options.sub {
         if let Some(sub) = claims.get("sub") {
             if from_value::<String>(sub.clone())? != *correct_sub {
@@ -142,6 +132,21 @@ pub fn validate(claims: &Map<String, Value>, options: &Validation) -> Result<()>
             }
         } else {
             return Err(new_error(ErrorKind::InvalidSubject));
+        }
+    }
+
+    if let Some(ref correct_iss) = options.iss {
+        if let Some(iss) = claims.get("iss") {
+            match iss {
+                Value::String(iss_found) => {
+                    if !correct_iss.contains(iss_found) {
+                        return Err(new_error(ErrorKind::InvalidIssuer));
+                    }
+                }
+                _ => return Err(new_error(ErrorKind::InvalidIssuer)),
+            };
+        } else {
+            return Err(new_error(ErrorKind::InvalidIssuer));
         }
     }
 
@@ -263,11 +268,11 @@ mod tests {
     fn iss_ok() {
         let mut claims = Map::new();
         claims.insert("iss".to_string(), to_value("Keats").unwrap());
-        let validation = Validation {
-            validate_exp: false,
-            iss: Some("Keats".to_string()),
-            ..Default::default()
-        };
+
+        let mut iss = std::collections::HashSet::new();
+        iss.insert("Keats".to_string());
+
+        let validation = Validation { validate_exp: false, iss: Some(iss), ..Default::default() };
         let res = validate(&claims, &validation);
         assert!(res.is_ok());
     }
@@ -276,11 +281,11 @@ mod tests {
     fn iss_not_matching_fails() {
         let mut claims = Map::new();
         claims.insert("iss".to_string(), to_value("Hacked").unwrap());
-        let validation = Validation {
-            validate_exp: false,
-            iss: Some("Keats".to_string()),
-            ..Default::default()
-        };
+
+        let mut iss = std::collections::HashSet::new();
+        iss.insert("Keats".to_string());
+
+        let validation = Validation { validate_exp: false, iss: Some(iss), ..Default::default() };
         let res = validate(&claims, &validation);
         assert!(res.is_err());
 
@@ -293,11 +298,11 @@ mod tests {
     #[test]
     fn iss_missing_fails() {
         let claims = Map::new();
-        let validation = Validation {
-            validate_exp: false,
-            iss: Some("Keats".to_string()),
-            ..Default::default()
-        };
+
+        let mut iss = std::collections::HashSet::new();
+        iss.insert("Keats".to_string());
+
+        let validation = Validation { validate_exp: false, iss: Some(iss), ..Default::default() };
         let res = validate(&claims, &validation);
         assert!(res.is_err());
 
@@ -424,10 +429,14 @@ mod tests {
     fn does_validation_in_right_order() {
         let mut claims = Map::new();
         claims.insert("exp".to_string(), to_value(get_current_timestamp() + 10000).unwrap());
+
+        let mut iss = std::collections::HashSet::new();
+        iss.insert("iss no check".to_string());
+
         let v = Validation {
             leeway: 5,
             validate_exp: true,
-            iss: Some("iss no check".to_string()),
+            iss: Some(iss),
             sub: Some("sub no check".to_string()),
             ..Validation::default()
         };

--- a/tests/hmac.rs
+++ b/tests/hmac.rs
@@ -31,6 +31,7 @@ fn verify_hs256() {
 }
 
 #[test]
+#[allow(clippy::field_reassign_with_default)]
 fn encode_with_custom_header() {
     let my_claims = Claims {
         sub: "b@b.com".to_string(),


### PR DESCRIPTION
Hello,

Some providers like [Google](https://developers.google.com/identity/sign-in/web/backend-auth) need to validate `iss` field against multiple values. It would be better to have `HashSet` type for `iss` field to validate multiple `iss` values instead of using multiple validation objects and multiple validations.