### PR TITLE
Updated base64 to v0.13 and simple_asn1 to v0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Updated `base64` to v0.13
+- Updated `simple_asn1` to v0.5
+
 ## 7.2.0 (2020-06-30)
 
 - Add `dangerous_insecure_decode` to replace `dangerous_unsafe_decode`, which is now deprecated

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 serde_json = "1.0"
 serde = {version = "1.0", features = ["derive"] }
 ring = { version = "0.16.5", features = ["std"] }
-base64 = "0.12"
+base64 = "0.13"
 # For PEM decoding
 pem = "0.8"
-simple_asn1 = "0.4"
+simple_asn1 = "0.5"
 
 [dev-dependencies]
 # For the custom chrono example

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -10,6 +10,9 @@ use crate::serialization::{b64_decode, b64_encode};
 pub(crate) mod ecdsa;
 pub(crate) mod rsa;
 
+// Wrapping is not necessary here but to remove it now would be a breaking
+// change in the API
+#[allow(clippy::clippy::unnecessary_wraps)]
 /// The actual HS signing + encoding
 /// Could be in its own file to match RSA/EC but it's 2 lines...
 pub(crate) fn sign_hmac(alg: hmac::Algorithm, key: &[u8], message: &str) -> Result<String> {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -69,9 +69,7 @@ pub struct Validation {
 impl Validation {
     /// Create a default validation setup allowing the given alg
     pub fn new(alg: Algorithm) -> Validation {
-        let mut validation = Validation::default();
-        validation.algorithms = vec![alg];
-        validation
+        Self { algorithms: vec![alg], ..Self::default() }
     }
 
     /// `aud` is a collection of one or more acceptable audience members


### PR DESCRIPTION
Hello! Thank you for your library, we have found it tremendously useful in our Rust video game projects over at Embark Studios.

We use [cargo-deny](https://github.com/EmbarkStudios/cargo-deny) to ensure we don't have multiple versions of the same deps, and it notified us that there was a duplicate resulting from this library using an older version.
This PR updates those deps to the latest version.

Thank you,
Louis