### PR TITLE
increasing performance over validation of audiences

### DIFF
--- a/src/validation.rs
+++ b/src/validation.rs
@@ -159,7 +159,7 @@ pub fn validate(claims: &Map<String, Value>, options: &Validation) -> Result<()>
                 }
                 Value::Array(_) => {
                     let provided_aud: HashSet<String> = from_value(aud.clone())?;
-                    if provided_aud.intersection(correct_aud).count() == 0 {
+                    if provided_aud.intersection(correct_aud).next().is_none() {
                         return Err(new_error(ErrorKind::InvalidAudience));
                     }
                 }


### PR DESCRIPTION
Hello,

We don't need to iterate over all possible hits in two sets by counting them, we just need the first hit to validate.