### PR TITLE
support jwk header field

### DIFF
--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -65,6 +65,24 @@ impl FromStr for Algorithm {
     }
 }
 
+impl ToString for Algorithm {
+    fn to_string(&self) -> String {
+        match self {
+            Algorithm::HS256 => "HS256".to_string(),
+            Algorithm::HS384 => "HS384".to_string(),
+            Algorithm::HS512 => "HS512".to_string(),
+            Algorithm::ES256 => "ES256".to_string(),
+            Algorithm::ES384 => "ES384".to_string(),
+            Algorithm::RS256 => "RS256".to_string(),
+            Algorithm::RS384 => "RS384".to_string(),
+            Algorithm::PS256 => "PS256".to_string(),
+            Algorithm::PS384 => "PS384".to_string(),
+            Algorithm::PS512 => "PS512".to_string(),
+            Algorithm::RS512 => "RS512".to_string(),
+        }
+    }
+}
+
 impl Algorithm {
     pub(crate) fn family(self) -> AlgorithmFamily {
         match self {

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,8 +1,32 @@
 use serde::{Deserialize, Serialize};
 
-use crate::algorithms::Algorithm;
-use crate::errors::Result;
-use crate::serialization::b64_decode;
+use crate::algorithms::{Algorithm, AlgorithmFamily};
+use crate::crypto::ecdsa::alg_to_ec_signing;
+use crate::encoding::EncodingKey;
+use crate::errors::{new_error, ErrorKind, Result};
+use crate::serialization::{b64_decode, b64_encode};
+use ring::signature::{EcdsaKeyPair, KeyPair, RsaKeyPair};
+
+#[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(tag = "kty")]
+pub enum JWK {
+    EC {
+        alg: String,
+        crv: String,
+        x: String,
+        y: String,
+    },
+    RSA {
+        alg: String,
+        n: String,
+        e: String,
+    },
+    #[serde(rename = "oct")]
+    Oct {
+        alg: String,
+        k: String,
+    },
+}
 
 /// A basic JWT header, the alg defaults to HS256 and typ is automatically
 /// set to `JWT`. All the other fields are optional.
@@ -27,6 +51,11 @@ pub struct Header {
     /// Defined in [RFC7515#4.1.2](https://tools.ietf.org/html/rfc7515#section-4.1.2).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jku: Option<String>,
+    /// JSON Web Key
+    ///
+    /// Defined in [RFC7515#4.1.3](https://tools.ietf.org/html/rfc7515#section-4.1.3).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jwk: Option<JWK>,
     /// Key ID
     ///
     /// Defined in [RFC7515#4.1.4](https://tools.ietf.org/html/rfc7515#section-4.1.4).
@@ -52,6 +81,7 @@ impl Header {
             alg: algorithm,
             cty: None,
             jku: None,
+            jwk: None,
             kid: None,
             x5u: None,
             x5t: None,
@@ -64,6 +94,52 @@ impl Header {
         let s = String::from_utf8(decoded)?;
 
         Ok(serde_json::from_str(&s)?)
+    }
+
+    /// Build a JSON Web Key object and add it to the header
+    pub fn add_jwk(&mut self, key: &EncodingKey) -> Result<()> {
+        if key.family != self.alg.family() {
+            return Err(new_error(ErrorKind::InvalidAlgorithm));
+        }
+
+        self.jwk = Some(match key.family {
+            AlgorithmFamily::Hmac => {
+                JWK::Oct { alg: self.alg.to_string(), k: b64_encode(&key.inner()) }
+            }
+            AlgorithmFamily::Ec => {
+                let alg = alg_to_ec_signing(self.alg);
+                let signing_key = EcdsaKeyPair::from_pkcs8(alg, &key.inner())?;
+                let pub_key = signing_key.public_key().as_ref();
+
+                if pub_key[0] != 0x04 || pub_key.len() != 65 {
+                    // TODO
+                    return Err(new_error(ErrorKind::InvalidAlgorithm));
+                }
+
+                JWK::EC {
+                    alg: self.alg.to_string(),
+                    crv: match self.alg {
+                        Algorithm::ES256 => "P-256".to_string(),
+                        Algorithm::ES384 => "P-384".to_string(),
+                        _ => unreachable!(),
+                    },
+                    x: b64_encode(&pub_key[1..33]),
+                    y: b64_encode(&pub_key[33..65]),
+                }
+            }
+            AlgorithmFamily::Rsa => {
+                let signing_key = RsaKeyPair::from_der(&key.inner())?;
+                let pub_key = signing_key.public_key();
+
+                JWK::RSA {
+                    alg: self.alg.to_string(),
+                    n: b64_encode(pub_key.modulus().big_endian_without_leading_zero()),
+                    e: b64_encode(pub_key.exponent().big_endian_without_leading_zero()),
+                }
+            }
+        });
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
**Motivation**

The ACME standard (RFC8555) requires the `jwk` header field:

>  For newAccount requests, and for revokeCert requests authenticated by
>  a certificate key, there MUST be a "jwk" field.  This field MUST
>  contain the public key corresponding to the private key used to sign
>  the JWS.


**Code examples**

<details>
  <summary>EC:</summary>

Code:

```rust
File: examples/jwk_ec_header.rs
use serde::{Deserialize, Serialize};

use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};

#[derive(Debug, Serialize, Deserialize)]
struct Claims {
    sub: String,
    company: String,
    exp: usize,
}

fn main() {
    let my_claims =
        Claims { sub: "b@b.com".to_owned(), company: "ACME".to_owned(), exp: 10000000000 };

    let privkey = include_bytes!("../tests/ecdsa/private_ecdsa_key.pk8");
    let pubkey = include_bytes!("../tests/ecdsa/public_ecdsa_key.pk8");

    let ekey = EncodingKey::from_ec_der(privkey);
    let dkey = DecodingKey::from_ec_der(pubkey);

    let mut header = Header::new(Algorithm::ES256);
    header.add_jwk(&ekey).unwrap();

    let token = match encode(&header, &my_claims, &ekey) {
        Ok(t) => t,
        Err(_) => panic!(), // in practice you would return the error
    };
    println!("{:?}", token);

    let token_data = decode::<Claims>(
        &token,
        &dkey,
        &Validation::new(Algorithm::ES256),
    ).unwrap();

    println!("{:#?}", token_data.claims);
    println!("{:#?}", token_data.header);
}
```

Output:

```
[pbb@regolith:~/proj/jsonwebtoken]$ RUST_BACKTRACE=1 cargo run --example jwk_ec_header
   Compiling jsonwebtoken v7.2.0 (/home/pbb/proj/jsonwebtoken)
    Finished dev [unoptimized + debuginfo] target(s) in 0.88s
     Running `target/debug/examples/jwk_ec_header`
"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImp3ayI6eyJrdHkiOiJFQyIsImFsZyI6IkVTMjU2IiwiY3J2IjoiUC0yNTYiLCJ4IjoidzdKQW9VX2dKYlpKdlYtekNPdlU5eUZKcTBGTkNfZWRDTVJNNzhQOGVRUSIsInkiOiJ3UWcxRXl0Y3NFbUdyTTcwR2I1M29sdW9EYlZoQ1ozVXEzaEhNc2xIVmI0In19.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUiLCJleHAiOjEwMDAwMDAwMDAwfQ.FIl5VSuduzQc1DicZrTqSeuBI1ApTvRBMm1R8YTy3Wa_kR8zH0CeeQLPgWPnquF1WpSVpO275rCcPMMexbjnLQ"
Claims {
    sub: "b@b.com",
    company: "ACME",
    exp: 10000000000,
}
Header {
    typ: Some(
        "JWT",
    ),
    alg: ES256,
    cty: None,
    jku: None,
    jwk: Some(
        EC {
            alg: "ES256",
            crv: "P-256",
            x: "w7JAoU_gJbZJvV-zCOvU9yFJq0FNC_edCMRM78P8eQQ",
            y: "wQg1EytcsEmGrM70Gb53oluoDbVhCZ3Uq3hHMslHVb4",
        },
    ),
    kid: None,
    x5u: None,
    x5t: None,
}

[pbb@regolith:~/proj/jsonwebtoken]$
```

</details>

<details>
  <summary>RSA:</summary>

Code:

```rust
File: examples/jwk_rsa_header.rs
use serde::{Deserialize, Serialize};

use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};

#[derive(Debug, Serialize, Deserialize)]
struct Claims {
    sub: String,
    company: String,
    exp: usize,
}

fn main() {
    let my_claims =
        Claims { sub: "b@b.com".to_owned(), company: "ACME".to_owned(), exp: 10000000000 };

    let privkey = include_bytes!("../tests/rsa/private_rsa_key.der");
    let pubkey = include_bytes!("../tests/rsa/public_rsa_key.der");

    let ekey = EncodingKey::from_rsa_der(privkey);
    let dkey = DecodingKey::from_rsa_der(pubkey);

    let mut header = Header::new(Algorithm::RS256);
    header.add_jwk(&ekey).unwrap();

    let token = match encode(&header, &my_claims, &ekey) {
        Ok(t) => t,
        Err(_) => panic!(), // in practice you would return the error
    };
    println!("{:?}", token);

    let token_data = decode::<Claims>(
        &token,
        &dkey,
        &Validation::new(Algorithm::RS256),
    ).unwrap();

    println!("{:#?}", token_data.claims);
    println!("{:#?}", token_data.header);
}
```

Output:

```
[pbb@regolith:~/proj/jsonwebtoken]$ RUST_BACKTRACE=1 cargo run --example jwk_rsa_header
   Compiling jsonwebtoken v7.2.0 (/home/pbb/proj/jsonwebtoken)
    Finished dev [unoptimized + debuginfo] target(s) in 1.22s
     Running `target/debug/examples/jwk_rsa_header`
"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp3ayI6eyJrdHkiOiJSU0EiLCJhbGciOiJSUzI1NiIsIm4iOiJ5UkU2ckh1TlIwUWJITzNIM0t0MnBPS0dWaFFxR1pYSW5PZHVRTnhYenVLbHZRVExVVHY0bDRzZ2doNV9DWVlpX2N2SS1TWFZUOWtQV1NLWHhKWEJYZF80TGt2Y1B1VWFrQm9Ba2ZoLWVpRlZNaDJWclV5V3lqM01GbDBIVFZGOUt3UlhMQWN3a1JFaVMzbnBUaEhSeUl4dXkwWk1lWmZ4Vkw1YXJNaHcxU1JFTEI4SG9HZkdfQXRIODlCSUU5akRCSFo5ZExlbEs5YTE4NHpBZjhMd29QTHh2SmIzSWw1bm5jcVBjU2ZLRERvZE1GQklNYzRsUXpES0w1Z3ZtaVhMWEIxQUdMbThLQmpmRThzM0w1eHFpLXlVb2QtajhNdHZJajgxMmRrUzRRTWlSVk5fYnkyaDNaWThMWVZHcnFaWFpUY2duMnVqbjh1S2pYTFpWRDVUZFEiLCJlIjoiQVFBQiJ9fQ.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUiLCJleHAiOjEwMDAwMDAwMDAwfQ.dKQB7s0sNgmet5CFC6_nWodWRQUsyN_D2Y2ma0EYNS9NcxVCU7BsKrgTlH1mYDxU8U0gxYqgBhXHDl2OeJf_rz5o9R5JizNXIEVB3U8RKoDtqXanRJKDzvBVq3Zr-ZErelk8oFos5wFy2TPiTWOeyNQ1Ny9f3R_6JbFy0SjRDpExEMhcsDeFD48VDx0xmQVznecQ73-yFFBehEH4CepyzC0-hjV-tmvLxiV1inkWbZsrw9BYR1lCdmIgPQ6KeMLwSWh4JkH-j_jy846POK6eJm1VEa8s3tPnvsJY1T0ME4Ft6c32zLKr9yp0PQY1x5Oy8bi2W8eV9NunVvH09gdMTw"
Claims {
    sub: "b@b.com",
    company: "ACME",
    exp: 10000000000,
}
Header {
    typ: Some(
        "JWT",
    ),
    alg: RS256,
    cty: None,
    jku: None,
    jwk: Some(
        RSA {
            alg: "RS256",
            n: "yRE6rHuNR0QbHO3H3Kt2pOKGVhQqGZXInOduQNxXzuKlvQTLUTv4l4sggh5_CYYi_cvI-SXVT9kPWSKXxJXBXd_4LkvcPuUakBoAkfh-eiFVMh2VrUyWyj3MFl0HTVF9KwRXLAcwkREiS3npThHRyIxuy0ZMeZfxVL5arMhw1SRELB8HoGfG_AtH89BIE9jDBHZ9dLelK9a184zAf8LwoPLxvJb3Il5nncqPcSfKDDodMFBIMc4lQzDKL5gvmiXLXB1AGLm8KBjfE8s3L5xqi-yUod-j8MtvIj812dkS4QMiRVN_by2h3ZY8LYVGrqZXZTcgn2ujn8uKjXLZVD5TdQ",
            e: "AQAB",
        },
    ),
    kid: None,
    x5u: None,
    x5t: None,
}

[pbb@regolith:~/proj/jsonwebtoken]$ 
```

</details>
