### PR TITLE
Added EC docs to Encoding & Decoding key

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,3 +195,18 @@ validation.set_audience(&["Me", "You"]); // array of strings
 ```
 
 Look at `examples/validation.rs` for a full working example.
+
+## Generating Epileptic Curve Key Pairs
+There are many ways to generate a key (pair), to encode, and subsequently decode, a JWT.
+One of the simplest ways is to use the `openssl` command line utility.
+
+Generate an EC private-key, and convert it to a valid pkcs8 formatted key.
+```
+openssl ecparam -name secp384r1 -genkey -noout -out private-key-sec1.pem
+openssl pkcs8 -topk8 -in private-key-sec1.pem -nocrypt -out private-key-pkcs8.pem
+```
+
+Generate an EC public-key, derived from the previously generated private key.
+```
+openssl ec -in keys/private-key.pem -pubout -out keys/public-key.pem
+```

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -37,6 +37,7 @@ pub(crate) enum DecodingKeyKind {
 
 /// All the different kind of keys we can use to decode a JWT
 /// This key can be re-used so make sure you only initialize it once if you can for better performance
+/// Currently only PKCS8 formatted EC keys are supported, ensure this format is selected when generating the key pair.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DecodingKey {
     pub(crate) family: AlgorithmFamily,

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -9,6 +9,7 @@ use crate::serialization::b64_encode_part;
 
 /// A key to encode a JWT with. Can be a secret, a PEM-encoded key or a DER-encoded key.
 /// This key can be re-used so make sure you only initialize it once if you can for better performance
+/// Currently only PKCS8 formatted EC keys are supported, ensure this format is selected when generating the key pair.
 #[derive(Debug, Clone, PartialEq)]
 pub struct EncodingKey {
     pub(crate) family: AlgorithmFamily,


### PR DESCRIPTION
Fixes #193.

Currently, the API docs for `EncodingKey` & `DecodingKey`, made no mention of the current key format limitations.
Also added instructions for EC key generation to the README.