### PR TITLE
Docs: fix copy paste error in ErrorKind::InvalidSubject

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -54,7 +54,7 @@ pub enum ErrorKind {
     InvalidIssuer,
     /// When a token’s `aud` claim does not match one of the expected audience values
     InvalidAudience,
-    /// When a token’s `aud` claim does not match one of the expected audience values
+    /// When a token’s `sub` claim does not match one of the expected audience values
     InvalidSubject,
     /// When a token’s nbf claim represents a time in the future
     ImmatureSignature,


### PR DESCRIPTION
The documentation for `ErrorKind::InvalidSubject` mentioned the `aud` claim instead of `sub`. This commit fixes it.