### PR TITLE
Fixing typo in doc comment

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -54,7 +54,7 @@ pub enum ErrorKind {
     InvalidIssuer,
     /// When a token’s `aud` claim does not match one of the expected audience values
     InvalidAudience,
-    /// When a token’s `aud` claim does not match one of the expected audience values
+    /// When a token’s `sub` claim does not match the expected subject
     InvalidSubject,
     /// When a token’s nbf claim represents a time in the future
     ImmatureSignature,


### PR DESCRIPTION
The doc comment for `InvalidSubject` is accidentally the same as the doc comment for `InvalidAudience`