### PR TITLE
Numeric type

### DIFF
--- a/src/validation.rs
+++ b/src/validation.rs
@@ -230,27 +230,6 @@ where
             formatter.write_str("A NumericType that can be reasonably coerced into a u64")
         }
 
-        //fn visit_unit<E>(self) -> std::result::Result<Self::Value, E>
-        //where
-        //    E: de::Error,
-        //{
-        //    Ok(TryParse::NotPresent)
-        //}
-
-        //fn visit_none<E>(self) -> std::result::Result<Self::Value, E>
-        //where
-        //    E: de::Error,
-        //{
-        //    Ok(TryParse::NotPresent)
-        //}
-
-        //fn visit_some<D>(self, deserializer: D) -> std::result::Result<Self::Value, D::Error>
-        //where
-        //    D: Deserializer<'de>,
-        //{
-        //    deserializer.deserialize_any(NumericType(PhantomData))
-        //}
-
         fn visit_f64<E>(self, value: f64) -> std::result::Result<Self::Value, E>
         where
             E: de::Error,


### PR DESCRIPTION
In order to properly align with JWT NumericType wire protocol allow for type on wire to either be u64 or f64. In either case we convert in the most lossless way possible to a u64, so that nobody needs to know that the spec is overly permissive.

Fixes: #212