### PR TITLE
Update  `simple_asn1` to `0.5`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ ring = { version = "0.16.5", features = ["std"] }
 base64 = "0.12"
 # For PEM decoding
 pem = "0.8"
-simple_asn1 = "0.4"
+simple_asn1 = "0.5"
 
 [dev-dependencies]
 # For the custom chrono example


### PR DESCRIPTION
This PR bumps the `simple_asn1` crate to its greatest and latest version, so that people can keep using `jsonwebtoken` in their projects.