### PR TITLE
Upgrade base64 to v0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 serde_json = "1.0"
 serde = {version = "1.0", features = ["derive"] }
 ring = { version = "0.16.5", features = ["std"] }
-base64 = "0.12"
+base64 = "0.13"
 # For PEM decoding
 pem = "0.8"
 simple_asn1 = "0.4"


### PR DESCRIPTION
Upgrades to the latest version of base64
Unfortunately, this could be considered a breaking change because `base64::DecodeError` is part of the public API as a variant of `ErrorKind`. But I will leave that decision up to the maintainers.