### PR TITLE
Upgrade from simple_asn1 0.4 -> 0.6 to address two RUSTSEC advisories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ ring = { version = "0.16.5", features = ["std"] }
 base64 = "0.12"
 # For PEM decoding
 pem = "0.8"
-simple_asn1 = "0.4"
+simple_asn1 = "0.6"
 
 [dev-dependencies]
 # For the custom chrono example

--- a/src/pem/decoder.rs
+++ b/src/pem/decoder.rs
@@ -1,7 +1,5 @@
 use crate::errors::{ErrorKind, Result};
 
-use simple_asn1::{BigUint, OID};
-
 /// Supported PEM files for EC and RSA Public and Private Keys
 #[derive(Debug, PartialEq)]
 enum PemType {


### PR DESCRIPTION
This removed a transitive dependency on `chrono` and upgrades a dependency on `time` to address the following security vulnerabilities. 

- https://rustsec.org/advisories/RUSTSEC-2020-0159.html
- https://rustsec.org/advisories/RUSTSEC-2020-0071.html