### PR TITLE
Update simple asn1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ ring = { version = "0.16.5", features = ["std"] }
 base64 = "0.12"
 # For PEM decoding
 pem = "0.8"
-simple_asn1 = "0.4"
+simple_asn1 = "0.6"
 
 [dev-dependencies]
 # For the custom chrono example

--- a/src/pem/decoder.rs
+++ b/src/pem/decoder.rs
@@ -1,7 +1,5 @@
 use crate::errors::{ErrorKind, Result};
 
-use simple_asn1::{BigUint, OID};
-
 /// Supported PEM files for EC and RSA Public and Private Keys
 #[derive(Debug, PartialEq)]
 enum PemType {


### PR DESCRIPTION
This drops a dependency on `chrono` which, by default, depends on `time 0.1` through its `oldtime` feature. This version of `time` has a security vulnerability, so bump to avoid adding the crate to dependency trees.