### PR TITLE
Fix algorithm family validation

### DIFF
--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -157,10 +157,8 @@ fn verify_signature<'a>(
     }
 
     if validation.validate_signature {
-        for alg in &validation.algorithms {
-            if key.family != alg.family() {
-                return Err(new_error(ErrorKind::InvalidAlgorithm));
-            }
+        if !validation.algorithms.iter().map(|a| a.family()).any(|f| f == key.family) {
+            return Err(new_error(ErrorKind::InvalidAlgorithm));
         }
     }
 


### PR DESCRIPTION
Algorithm family validation currently fails when supported algorithm are from different families.
For example 
```rust
validation.algorithms = vec![Algorithm::EdDSA, Algorithm::ES256];
```
will fail validating ES256 signed JWS whereas it should