### PR TITLE
Fix algorithm family validation

### DIFF
--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -157,10 +157,8 @@ fn verify_signature<'a>(
     }
 
     if validation.validate_signature {
-        for alg in &validation.algorithms {
-            if key.family != alg.family() {
-                return Err(new_error(ErrorKind::InvalidAlgorithm));
-            }
+        if !validation.algorithms.iter().any(|alg| key.family == alg.family()) {
+            return Err(new_error(ErrorKind::InvalidAlgorithm));
         }
     }
 


### PR DESCRIPTION
I've noticed that when `Validation` has algorithms of different families
only the first one was being validated.

For example. if we have:
```Rust
let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::RS256);
validation.algorithms.push(jsonwebtoken::Algorithm::RS384);
validation.algorithms.push(jsonwebtoken::Algorithm::ES384);
validation.algorithms.push(jsonwebtoken::Algorithm::ES256);
```

Only `AlgorithmFamily::Rsa` would be accepted in the JWT instead of
`AlgorithmFamily::Ec` also being acceptable.

This change ensures that all algorithm families are checked.
