### PR TITLE
Creating DecodingKey from jwk

### DIFF
--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -219,6 +219,9 @@ pub enum EllipticCurve {
     /// P-521 curve -- unsupported by `ring`.
     #[serde(rename = "P-521")]
     P521,
+    /// Ed25519 curve
+    #[serde(rename = "Ed25519")]
+    Ed25519,
 }
 
 impl Default for EllipticCurve {

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -68,6 +68,32 @@ fn round_trip_claim() {
     assert_eq!(my_claims, token_data.claims);
 }
 
+#[cfg(feature = "use_pem")]
+#[test]
+fn ec_x_y() {
+    let privkey = include_str!("private_ecdsa_key.pem");
+    let my_claims = Claims {
+        sub: "b@b.com".to_string(),
+        company: "ACME".to_string(),
+        exp: OffsetDateTime::now_utc().unix_timestamp() + 10000,
+    };
+    let x = "w7JAoU_gJbZJvV-zCOvU9yFJq0FNC_edCMRM78P8eQQ";
+    let y = "wQg1EytcsEmGrM70Gb53oluoDbVhCZ3Uq3hHMslHVb4";
+
+    let encrypted = encode(
+        &Header::new(Algorithm::ES256),
+        &my_claims,
+        &EncodingKey::from_ec_pem(privkey.as_ref()).unwrap(),
+    )
+    .unwrap();
+    let res = decode::<Claims>(
+        &encrypted,
+        &DecodingKey::from_ec_components(x, y).unwrap(),
+        &Validation::new(Algorithm::ES256),
+    );
+    assert!(res.is_ok());
+}
+
 // https://jwt.io/ is often used for examples so ensure their example works with jsonwebtoken
 #[cfg(feature = "use_pem")]
 #[test]

--- a/tests/eddsa/mod.rs
+++ b/tests/eddsa/mod.rs
@@ -67,3 +67,28 @@ fn round_trip_claim() {
     .unwrap();
     assert_eq!(my_claims, token_data.claims);
 }
+
+#[cfg(feature = "use_pem")]
+#[test]
+fn ed_x() {
+    let privkey = include_str!("private_ed25519_key.pem");
+    let my_claims = Claims {
+        sub: "b@b.com".to_string(),
+        company: "ACME".to_string(),
+        exp: OffsetDateTime::now_utc().unix_timestamp() + 10000,
+    };
+    let x = "2-Jj2UvNCvQiUPNYRgSi0cJSPiJI6Rs6D0UTeEpQVj8";
+
+    let encrypted = encode(
+        &Header::new(Algorithm::EdDSA),
+        &my_claims,
+        &EncodingKey::from_ed_pem(privkey.as_ref()).unwrap(),
+    )
+    .unwrap();
+    let res = decode::<Claims>(
+        &encrypted,
+        &DecodingKey::from_ed_components(x).unwrap(),
+        &Validation::new(Algorithm::EdDSA),
+    );
+    assert!(res.is_ok());
+}

--- a/tests/rsa/mod.rs
+++ b/tests/rsa/mod.rs
@@ -127,6 +127,41 @@ fn rsa_modulus_exponent() {
     assert!(res.is_ok());
 }
 
+#[cfg(feature = "use_pem")]
+#[test]
+fn rsa_jwk() {
+    use jsonwebtoken::jwk::Jwk;
+    use serde_json::json;
+
+    let privkey = include_str!("private_rsa_key_pkcs8.pem");
+    let my_claims = Claims {
+        sub: "b@b.com".to_string(),
+        company: "ACME".to_string(),
+        exp: OffsetDateTime::now_utc().unix_timestamp() + 10000,
+    };
+    let jwk:Jwk = serde_json::from_value(json!({
+        "kty": "RSA",
+        "n": "yRE6rHuNR0QbHO3H3Kt2pOKGVhQqGZXInOduQNxXzuKlvQTLUTv4l4sggh5_CYYi_cvI-SXVT9kPWSKXxJXBXd_4LkvcPuUakBoAkfh-eiFVMh2VrUyWyj3MFl0HTVF9KwRXLAcwkREiS3npThHRyIxuy0ZMeZfxVL5arMhw1SRELB8HoGfG_AtH89BIE9jDBHZ9dLelK9a184zAf8LwoPLxvJb3Il5nncqPcSfKDDodMFBIMc4lQzDKL5gvmiXLXB1AGLm8KBjfE8s3L5xqi-yUod-j8MtvIj812dkS4QMiRVN_by2h3ZY8LYVGrqZXZTcgn2ujn8uKjXLZVD5TdQ",
+        "e": "AQAB",
+        "kid": "rsa01",
+        "alg": "RS256",
+        "use": "sig"
+    })).unwrap();
+
+    let encrypted = encode(
+        &Header::new(Algorithm::RS256),
+        &my_claims,
+        &EncodingKey::from_rsa_pem(privkey.as_ref()).unwrap(),
+    )
+    .unwrap();
+    let res = decode::<Claims>(
+        &encrypted,
+        &DecodingKey::from_jwk(&jwk).unwrap(),
+        &Validation::new(Algorithm::RS256),
+    );
+    assert!(res.is_ok());
+}
+
 // https://jwt.io/ is often used for examples so ensure their example works with jsonwebtoken
 #[cfg(feature = "use_pem")]
 #[test]


### PR DESCRIPTION
- adding DecodingKey:from_ec_components DecodingKey:from_ed_components (equivalent of existing DecodingKey:from_rsa_components for ECDSA and EdDSA)
- adding tests
- adding DecodingKey:from_jwk
- adding tests for rsa, ecdsa and eddsa