### PR TITLE
fix ci: bump pinned rustc version to 1.59 (fixes #268)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-20.04
-          rust: 1.56.0
+          rust: 1.59.0
         - build: stable
           os: ubuntu-20.04
           rust: stable

--- a/src/header.rs
+++ b/src/header.rs
@@ -9,7 +9,7 @@ use crate::serialization::b64_decode;
 
 /// A basic JWT header, the alg defaults to HS256 and typ is automatically
 /// set to `JWT`. All the other fields are optional.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct Header {
     /// The type of JWS: it can only be "JWT" here
     ///

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -350,7 +350,7 @@ pub struct Jwk {
 }
 
 /// A JWK set
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct JwkSet {
     pub keys: Vec<Jwk>,
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -26,7 +26,7 @@ use crate::errors::{new_error, ErrorKind, Result};
 /// validation.set_issuer(&["Me"]); // a single string
 /// validation.set_issuer(&["Me", "You"]); // array of strings
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Validation {
     /// Which claims are required to be present before starting the validation.
     /// This does not interact with the various `validate_*`. If you remove `exp` from that list, you still need

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -5,7 +5,7 @@ use jsonwebtoken::{
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Claims {
     sub: String,
     company: String,

--- a/tests/eddsa/mod.rs
+++ b/tests/eddsa/mod.rs
@@ -5,7 +5,7 @@ use jsonwebtoken::{
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Claims {
     sub: String,
     company: String,

--- a/tests/hmac.rs
+++ b/tests/hmac.rs
@@ -6,7 +6,7 @@ use jsonwebtoken::{
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Claims {
     sub: String,
     company: String,

--- a/tests/rsa/mod.rs
+++ b/tests/rsa/mod.rs
@@ -14,7 +14,7 @@ const RSA_ALGORITHMS: &[Algorithm] = &[
     Algorithm::PS512,
 ];
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Claims {
     sub: String,
     company: String,


### PR DESCRIPTION
Bumping the rustc version needed by dev dependency time 0.3.15 (derived from "0.3") that is now supporting rustc 1.59+.