### PR TITLE
Fixed decoding of token when validation has multiple families of algorithms

### DIFF
--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -156,12 +156,10 @@ fn verify_signature<'a>(
         return Err(new_error(ErrorKind::MissingAlgorithm));
     }
 
-    if validation.validate_signature {
-        for alg in &validation.algorithms {
-            if key.family != alg.family() {
-                return Err(new_error(ErrorKind::InvalidAlgorithm));
-            }
-        }
+    if validation.validate_signature
+        && !validation.algorithms.iter().any(|alg| key.family == alg.family())
+    {
+        return Err(new_error(ErrorKind::InvalidAlgorithm));
     }
 
     let (signature, message) = expect_two!(token.rsplitn(2, '.'));


### PR DESCRIPTION
Currently if you have

```rust
        let mut validation = Validation::default();
        validation.algorithms = vec![
            Algorithm::HS256,
            Algorithm::HS384,
            Algorithm::HS512,
            Algorithm::RS256,
            Algorithm::RS384,
            Algorithm::RS512,
        ];
```

and try to validate a `RS256` signed token, you will get a `Error::InvalidAlgorithm` due to the section:
```rust
        for alg in &validation.algorithms {
            if key.family != alg.family() {
                return Err(new_error(ErrorKind::InvalidAlgorithm));
            }
        }
```

This section should check whether the key is one of the accepted families. Currently it checks if an algorithm is accepted with a different family, and if so rejects the key.