### PR TITLE
style: use non-reference patterns instead of explicit ref in patterns

### DIFF
--- a/examples/auth0.rs
+++ b/examples/auth0.rs
@@ -18,8 +18,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         None => return Err("Token doesn't have a `kid` header field".into()),
     };
     if let Some(j) = jwks.find(&kid) {
-        match j.algorithm {
-            AlgorithmParameters::RSA(ref rsa) => {
+        match &j.algorithm {
+            AlgorithmParameters::RSA(rsa) => {
                 let decoding_key = DecodingKey::from_rsa_components(&rsa.n, &rsa.e).unwrap();
                 let mut validation = Validation::new(j.common.algorithm.unwrap());
                 validation.validate_exp = false;

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -165,19 +165,15 @@ impl DecodingKey {
 
     /// If you have a key in Jwk format
     pub fn from_jwk(jwk: &Jwk) -> Result<Self> {
-        match jwk.algorithm {
-            AlgorithmParameters::RSA(ref params) => {
+        match &jwk.algorithm {
+            AlgorithmParameters::RSA(params) => {
                 DecodingKey::from_rsa_components(&params.n, &params.e)
             }
-            AlgorithmParameters::EllipticCurve(ref params) => {
+            AlgorithmParameters::EllipticCurve(params) => {
                 DecodingKey::from_ec_components(&params.x, &params.y)
             }
-            AlgorithmParameters::OctetKeyPair(ref params) => {
-                DecodingKey::from_ed_components(&params.x)
-            }
-            AlgorithmParameters::OctetKey(ref params) => {
-                DecodingKey::from_base64_secret(&params.value)
-            }
+            AlgorithmParameters::OctetKeyPair(params) => DecodingKey::from_ed_components(&params.x),
+            AlgorithmParameters::OctetKey(params) => DecodingKey::from_base64_secret(&params.value),
         }
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -82,7 +82,7 @@ pub enum ErrorKind {
 
 impl StdError for Error {
     fn cause(&self) -> Option<&dyn StdError> {
-        match *self.0 {
+        match &*self.0 {
             ErrorKind::InvalidToken => None,
             ErrorKind::InvalidSignature => None,
             ErrorKind::InvalidEcdsaKey => None,
@@ -98,17 +98,17 @@ impl StdError for Error {
             ErrorKind::InvalidAlgorithm => None,
             ErrorKind::InvalidAlgorithmName => None,
             ErrorKind::InvalidKeyFormat => None,
-            ErrorKind::Base64(ref err) => Some(err),
-            ErrorKind::Json(ref err) => Some(err.as_ref()),
-            ErrorKind::Utf8(ref err) => Some(err),
-            ErrorKind::Crypto(ref err) => Some(err),
+            ErrorKind::Base64(err) => Some(err),
+            ErrorKind::Json(err) => Some(err.as_ref()),
+            ErrorKind::Utf8(err) => Some(err),
+            ErrorKind::Crypto(err) => Some(err),
         }
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self.0 {
+        match &*self.0 {
             ErrorKind::InvalidToken
             | ErrorKind::InvalidSignature
             | ErrorKind::InvalidEcdsaKey
@@ -122,12 +122,12 @@ impl fmt::Display for Error {
             | ErrorKind::InvalidAlgorithm
             | ErrorKind::InvalidKeyFormat
             | ErrorKind::InvalidAlgorithmName => write!(f, "{:?}", self.0),
-            ErrorKind::MissingRequiredClaim(ref c) => write!(f, "Missing required claim: {}", c),
-            ErrorKind::InvalidRsaKey(ref msg) => write!(f, "RSA key invalid: {}", msg),
-            ErrorKind::Json(ref err) => write!(f, "JSON error: {}", err),
-            ErrorKind::Utf8(ref err) => write!(f, "UTF-8 error: {}", err),
-            ErrorKind::Crypto(ref err) => write!(f, "Crypto error: {}", err),
-            ErrorKind::Base64(ref err) => write!(f, "Base64 error: {}", err),
+            ErrorKind::MissingRequiredClaim(c) => write!(f, "Missing required claim: {}", c),
+            ErrorKind::InvalidRsaKey(msg) => write!(f, "RSA key invalid: {}", msg),
+            ErrorKind::Json(err) => write!(f, "JSON error: {}", err),
+            ErrorKind::Utf8(err) => write!(f, "UTF-8 error: {}", err),
+            ErrorKind::Crypto(err) => write!(f, "Crypto error: {}", err),
+            ErrorKind::Base64(err) => write!(f, "Base64 error: {}", err),
         }
     }
 }

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -24,10 +24,10 @@ impl Serialize for PublicKeyUse {
     where
         S: Serializer,
     {
-        let string = match *self {
+        let string = match self {
             PublicKeyUse::Signature => "sig",
             PublicKeyUse::Encryption => "enc",
-            PublicKeyUse::Other(ref other) => other,
+            PublicKeyUse::Other(other) => other,
         };
 
         serializer.serialize_str(string)
@@ -91,7 +91,7 @@ impl Serialize for KeyOperations {
     where
         S: Serializer,
     {
-        let string = match *self {
+        let string = match self {
             KeyOperations::Sign => "sign",
             KeyOperations::Verify => "verify",
             KeyOperations::Encrypt => "encrypt",
@@ -100,7 +100,7 @@ impl Serialize for KeyOperations {
             KeyOperations::UnwrapKey => "unwrapKey",
             KeyOperations::DeriveKey => "deriveKey",
             KeyOperations::DeriveBits => "deriveBits",
-            KeyOperations::Other(ref other) => other,
+            KeyOperations::Other(other) => other,
         };
 
         serializer.serialize_str(string)


### PR DESCRIPTION
By using non-reference patterns to match references, the `ref` keyword becomes unnecessary as it is added by the desugaring.
