### PR TITLE
Implement Clone for TokenData<T> if T: Clone

### DIFF
--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -20,6 +20,15 @@ pub struct TokenData<T> {
     pub claims: T,
 }
 
+impl<T> Clone for TokenData<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Self { header: self.header.clone(), claims: self.claims.clone() }
+    }
+}
+
 /// Takes the result of a rsplit and ensure we only get 2 parts
 /// Errors if we don't
 macro_rules! expect_two {


### PR DESCRIPTION
If T: Clone, we can write a Clone implementation for `TokenData`.