### PR TITLE
Add optional support for 3rd party time libraries like `time` and `chrono`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,9 @@ jobs:
 
     - name: Run tests no features
       run: cargo test --no-default-features
+
+    - name: Run tests with time
+      run: cargo test --features default_time
+
+    - name: Run tests with chrono
+      run: cargo test --features default_chrono

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - run: cargo clippy --all-targets --features pem -- -D warnings
+      - run: cargo clippy --all-targets --features pem,default_time -- -D warnings
+      - run: cargo clippy --all-targets --features pem,default_chrono -- -D warnings
 
   tests:
     name: Tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ base64 = "0.21.0"
 # For PEM decoding
 pem = {version = "1", optional = true}
 simple_asn1 = {version = "0.6", optional = true}
-time = {version = "0.3", optional = true, features = ["serde", "parsing"] }
-chrono = {version = "0.3", optional = true, features = ["serde"] }
+time = {version = "0.3", optional = true }
+chrono = {version = "0.3", optional = true }
 
 [dev-dependencies]
 # For the custom time example

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,6 @@ default = ["use_pem"]
 use_pem = ["pem", "simple_asn1"]
 default_time = ["time"]
 default_chrono = ["chrono"]
-time = ["dep:time"]
-chrono = ["dep:chrono"]
 
 [[bench]]
 name = "jwt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ base64 = "0.21.0"
 # For PEM decoding
 pem = {version = "1", optional = true}
 simple_asn1 = {version = "0.6", optional = true}
+time = {version = "0.3", optional = true, features = ["serde", "parsing"] }
+chrono = {version = "0.3", optional = true, features = ["serde"] }
 
 [dev-dependencies]
 # For the custom time example
@@ -29,6 +31,10 @@ criterion = "0.4"
 [features]
 default = ["use_pem"]
 use_pem = ["pem", "simple_asn1"]
+default_time = ["time"]
+default_chrono = ["chrono"]
+time = ["dep:time"]
+chrono = ["dep:chrono"]
 
 [[bench]]
 name = "jwt"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,24 @@ serde = {version = "1.0", features = ["derive"] }
 
 The minimum required Rust version is 1.56.
 
+## Cargo features
+
+By default, this crate uses `std::time` to compare timestamps and does not depend on `time` and `chrono`.
+This comes with a significant caveat: token expiration validation checks assume that the system's timezone is UTC. If 
+the system's timezone is not UTC, token expiration checks will be wrong.
+
+To alleviate this issue, you can use a timezone-aware time library like `time` or `chrono`. To make `time` the default
+time library used by `jsonwebtoken`, enable the `default_time` feature of this crate. Similarly, to make `chrono`
+the default, enable the `default_chrono` feature. For example:
+```
+jsonwebtoken = { version = "8", features = ["pem", "default_chrono"] }
+```
+
+You can also enable both `time` and `chrono` support without making them the default time library used by this crate 
+by enabling the `time` and `chrono` features. You will then be able to specify which library to use using the 
+`validate_with_options` function. Unlike `default_time` and `default_chrono`, these cargo features are not mutually 
+exclusive.
+
 ## Algorithms
 This library currently supports the following:
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jsonwebtoken = { version = "8", features = ["pem", "default_chrono"] }
 
 You can also enable both `time` and `chrono` support without making them the default time library used by this crate 
 by enabling the `time` and `chrono` features. You will then be able to specify which library to use using the 
-`validate_with_options` function. Unlike `default_time` and `default_chrono`, these cargo features are not mutually 
+`decode_with_options` function. Unlike `default_time` and `default_chrono`, these cargo features are not mutually 
 exclusive.
 
 ## Algorithms

--- a/examples/ed25519.rs
+++ b/examples/ed25519.rs
@@ -1,5 +1,6 @@
+use std::time::SystemTime;
 use jsonwebtoken::{
-    decode, encode, get_current_timestamp, Algorithm, DecodingKey, EncodingKey, Validation,
+    decode, encode, Algorithm, DecodingKey, EncodingKey, Validation,
 };
 use ring::signature::{Ed25519KeyPair, KeyPair};
 use serde::{Deserialize, Serialize};
@@ -17,7 +18,8 @@ fn main() {
     let pair = Ed25519KeyPair::from_pkcs8(doc.as_ref()).unwrap();
     let decoding_key = DecodingKey::from_ed_der(pair.public_key().as_ref());
 
-    let claims = Claims { sub: "test".to_string(), exp: get_current_timestamp() };
+    let exp = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs();
+    let claims = Claims { sub: "test".to_string(), exp: exp };
 
     let token =
         encode(&jsonwebtoken::Header::new(Algorithm::EdDSA), &claims, &encoding_key).unwrap();

--- a/examples/ed25519.rs
+++ b/examples/ed25519.rs
@@ -1,9 +1,7 @@
-use std::time::SystemTime;
-use jsonwebtoken::{
-    decode, encode, Algorithm, DecodingKey, EncodingKey, Validation,
-};
+use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Validation};
 use ring::signature::{Ed25519KeyPair, KeyPair};
 use serde::{Deserialize, Serialize};
+use std::time::SystemTime;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {

--- a/examples/ed25519.rs
+++ b/examples/ed25519.rs
@@ -17,7 +17,7 @@ fn main() {
     let decoding_key = DecodingKey::from_ed_der(pair.public_key().as_ref());
 
     let exp = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs();
-    let claims = Claims { sub: "test".to_string(), exp: exp };
+    let claims = Claims { sub: "test".to_string(), exp };
 
     let token =
         encode(&jsonwebtoken::Header::new(Algorithm::EdDSA), &claims, &encoding_key).unwrap();

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -1,7 +1,7 @@
-use std::time::SystemTime;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer};
+use std::time::SystemTime;
 
 use crate::algorithms::AlgorithmFamily;
 use crate::crypto::verify;
@@ -11,7 +11,9 @@ use crate::jwk::{AlgorithmParameters, Jwk};
 #[cfg(feature = "use_pem")]
 use crate::pem::decoder::PemEncodedKey;
 use crate::serialization::{b64_decode, DecodedJwtPartClaims};
-use crate::time::{DefaultTimestampOptions, JwtInstant, SerdeSystemTimeFromSeconds, TimestampOptions};
+use crate::time::{
+    DefaultTimestampOptions, JwtInstant, SerdeSystemTimeFromSeconds, TimestampOptions,
+};
 use crate::validation::{validate, Validation};
 
 /// The return type of a successful call to [decode](fn.decode.html).

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -1,7 +1,7 @@
+#![allow(unused_imports)]
+
 use base64::{engine::general_purpose::STANDARD, Engine};
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Deserializer};
-use std::time::SystemTime;
 
 use crate::algorithms::AlgorithmFamily;
 use crate::crypto::verify;
@@ -290,7 +290,7 @@ pub fn decode_with_options<T: DeserializeOwned, DO: DecodingOptions>(
     token: &str,
     key: &DecodingKey,
     validation: &Validation,
-    options: &DO,
+    _options: &DO,
 ) -> Result<TokenData<T>> {
     match verify_signature(token, key, validation) {
         Err(e) => Err(e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,12 @@ pub mod jwk;
 mod pem;
 mod serialization;
 mod validation;
+/// Compatibility types for deserializing and comparing timestamps
+pub mod time;
 
 pub use algorithms::Algorithm;
-pub use decoding::{decode, decode_header, DecodingKey, TokenData};
+pub use decoding::{decode, decode_with_options, decode_header, DecodingKey, TokenData,
+                   DecodingOptions, DefaultDecodingOptions};
 pub use encoding::{encode, EncodingKey};
 pub use header::Header;
-pub use validation::{get_current_timestamp, Validation};
+pub use validation::Validation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,13 +15,15 @@ pub mod jwk;
 #[cfg(feature = "use_pem")]
 mod pem;
 mod serialization;
-mod validation;
 /// Compatibility types for deserializing and comparing timestamps
 pub mod time;
+mod validation;
 
 pub use algorithms::Algorithm;
-pub use decoding::{decode, decode_with_options, decode_header, DecodingKey, TokenData,
-                   DecodingOptions, DefaultDecodingOptions};
+pub use decoding::{
+    decode, decode_header, decode_with_options, DecodingKey, DecodingOptions,
+    DefaultDecodingOptions, TokenData,
+};
 pub use encoding::{encode, EncodingKey};
 pub use header::Header;
 pub use validation::Validation;

--- a/src/time/chrono.rs
+++ b/src/time/chrono.rs
@@ -1,0 +1,91 @@
+use std::fmt::Formatter;
+use serde::de::{Error, Visitor};
+use serde::{Deserialize, Deserializer};
+use chrono::{DateTime, TimeZone};
+use crate::decoding::DecodingOptions;
+use crate::time::{JwtInstant};
+
+/// Deserializes [`chrono::DateTime`] from a UNIX timestamp or an RFC3339 timestamp.
+pub struct ChronoDateTimeUtcUnixTimestampOrRFC3339(chrono::DateTime<chrono::UTC>);
+
+struct SerdeChronoDateTimeUtcAsSecondsVisitor;
+
+impl<'de> Visitor<'de> for SerdeChronoDateTimeUtcAsSecondsVisitor {
+    type Value = ChronoDateTimeUtcUnixTimestampOrRFC3339;
+
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        formatter.write_str(
+            "an integer or float representing a unix timestamp, or an RFC3339 timestamp string"
+        )
+    }
+
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: Error {
+        Ok(ChronoDateTimeUtcUnixTimestampOrRFC3339(chrono::UTC.timestamp(v, 0)))
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: Error {
+        Ok(ChronoDateTimeUtcUnixTimestampOrRFC3339(chrono::UTC.timestamp(v as i64, 0)))
+    }
+
+    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E> where E: Error {
+        let duration = std::time::Duration::from_secs_f32(v);
+        Ok(ChronoDateTimeUtcUnixTimestampOrRFC3339(
+            chrono::UTC.timestamp(
+                duration.as_secs() as i64,
+                duration.subsec_nanos(),
+            )
+        ))
+    }
+
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E> where E: Error {
+        let duration = std::time::Duration::from_secs_f64(v);
+        Ok(ChronoDateTimeUtcUnixTimestampOrRFC3339(
+            chrono::UTC.timestamp(
+                duration.as_secs() as i64,
+                duration.subsec_nanos(),
+            )
+        ))
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: Error {
+        match chrono::DateTime::parse_from_rfc3339(v) {
+            Ok(t) => Ok(
+                ChronoDateTimeUtcUnixTimestampOrRFC3339(t.with_timezone(&chrono::UTC))
+            ),
+            Err(err) => {
+                Err(E::custom("Invalid timestamp format"))
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ChronoDateTimeUtcUnixTimestampOrRFC3339 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+        deserializer.deserialize_any(SerdeChronoDateTimeUtcAsSecondsVisitor)
+    }
+}
+
+impl<'a> From<&'a ChronoDateTimeUtcUnixTimestampOrRFC3339> for chrono::DateTime<chrono::UTC> {
+    fn from(value: &'a ChronoDateTimeUtcUnixTimestampOrRFC3339) -> Self {
+        value.0
+    }
+}
+
+
+impl JwtInstant for chrono::DateTime<chrono::UTC> {
+    fn now() -> Self {
+        chrono::UTC::now()
+    }
+
+    fn is_before(&self, other: &Self) -> bool {
+        *self < *other
+    }
+
+    fn is_after(&self, other: &Self) -> bool {
+        *self > *other
+    }
+
+    fn with_added_seconds(&self, seconds: u64) -> Self {
+        *self + chrono::Duration::seconds(seconds as i64)
+    }
+}

--- a/src/time/chrono.rs
+++ b/src/time/chrono.rs
@@ -1,6 +1,5 @@
-use crate::decoding::DecodingOptions;
 use crate::time::JwtInstant;
-use chrono::{DateTime, TimeZone};
+use chrono::TimeZone;
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer};
 use std::fmt::Formatter;
@@ -17,28 +16,11 @@ impl<'de> Visitor<'de> for SerdeChronoDateTimeUtcAsSecondsVisitor {
         formatter.write_str("an integer or float representing a unix timestamp")
     }
 
-    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        Ok(ChronoDateTimeUtcUnixTimestamp(chrono::UTC.timestamp(v, 0)))
-    }
-
     fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
     where
         E: Error,
     {
         Ok(ChronoDateTimeUtcUnixTimestamp(chrono::UTC.timestamp(v as i64, 0)))
-    }
-
-    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        let duration = std::time::Duration::from_secs_f32(v);
-        Ok(ChronoDateTimeUtcUnixTimestamp(
-            chrono::UTC.timestamp(duration.as_secs() as i64, duration.subsec_nanos()),
-        ))
     }
 
     fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>

--- a/src/time/chrono.rs
+++ b/src/time/chrono.rs
@@ -1,9 +1,9 @@
-use std::fmt::Formatter;
+use crate::decoding::DecodingOptions;
+use crate::time::JwtInstant;
+use chrono::{DateTime, TimeZone};
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer};
-use chrono::{DateTime, TimeZone};
-use crate::decoding::DecodingOptions;
-use crate::time::{JwtInstant};
+use std::fmt::Formatter;
 
 /// Deserializes [`chrono::DateTime`] from a UNIX timestamp or an RFC3339 timestamp.
 pub struct ChronoDateTimeUtcUnixTimestampOrRFC3339(chrono::DateTime<chrono::UTC>);
@@ -15,52 +15,60 @@ impl<'de> Visitor<'de> for SerdeChronoDateTimeUtcAsSecondsVisitor {
 
     fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
         formatter.write_str(
-            "an integer or float representing a unix timestamp, or an RFC3339 timestamp string"
+            "an integer or float representing a unix timestamp, or an RFC3339 timestamp string",
         )
     }
 
-    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: Error {
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
         Ok(ChronoDateTimeUtcUnixTimestampOrRFC3339(chrono::UTC.timestamp(v, 0)))
     }
 
-    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: Error {
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
         Ok(ChronoDateTimeUtcUnixTimestampOrRFC3339(chrono::UTC.timestamp(v as i64, 0)))
     }
 
-    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E> where E: Error {
+    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
         let duration = std::time::Duration::from_secs_f32(v);
         Ok(ChronoDateTimeUtcUnixTimestampOrRFC3339(
-            chrono::UTC.timestamp(
-                duration.as_secs() as i64,
-                duration.subsec_nanos(),
-            )
+            chrono::UTC.timestamp(duration.as_secs() as i64, duration.subsec_nanos()),
         ))
     }
 
-    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E> where E: Error {
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
         let duration = std::time::Duration::from_secs_f64(v);
         Ok(ChronoDateTimeUtcUnixTimestampOrRFC3339(
-            chrono::UTC.timestamp(
-                duration.as_secs() as i64,
-                duration.subsec_nanos(),
-            )
+            chrono::UTC.timestamp(duration.as_secs() as i64, duration.subsec_nanos()),
         ))
     }
 
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: Error {
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
         match chrono::DateTime::parse_from_rfc3339(v) {
-            Ok(t) => Ok(
-                ChronoDateTimeUtcUnixTimestampOrRFC3339(t.with_timezone(&chrono::UTC))
-            ),
-            Err(err) => {
-                Err(E::custom("Invalid timestamp format"))
-            }
+            Ok(t) => Ok(ChronoDateTimeUtcUnixTimestampOrRFC3339(t.with_timezone(&chrono::UTC))),
+            Err(err) => Err(E::custom("Invalid timestamp format")),
         }
     }
 }
 
 impl<'de> Deserialize<'de> for ChronoDateTimeUtcUnixTimestampOrRFC3339 {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
         deserializer.deserialize_any(SerdeChronoDateTimeUtcAsSecondsVisitor)
     }
 }
@@ -70,7 +78,6 @@ impl<'a> From<&'a ChronoDateTimeUtcUnixTimestampOrRFC3339> for chrono::DateTime<
         value.0
     }
 }
-
 
 impl JwtInstant for chrono::DateTime<chrono::UTC> {
     fn now() -> Self {

--- a/src/time/chrono.rs
+++ b/src/time/chrono.rs
@@ -5,32 +5,30 @@ use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer};
 use std::fmt::Formatter;
 
-/// Deserializes [`chrono::DateTime`] from a UNIX timestamp or an RFC3339 timestamp.
-pub struct ChronoDateTimeUtcUnixTimestampOrRFC3339(chrono::DateTime<chrono::UTC>);
+/// Deserializes [`chrono::DateTime`] from a UNIX timestamp
+pub struct ChronoDateTimeUtcUnixTimestamp(chrono::DateTime<chrono::UTC>);
 
 struct SerdeChronoDateTimeUtcAsSecondsVisitor;
 
 impl<'de> Visitor<'de> for SerdeChronoDateTimeUtcAsSecondsVisitor {
-    type Value = ChronoDateTimeUtcUnixTimestampOrRFC3339;
+    type Value = ChronoDateTimeUtcUnixTimestamp;
 
     fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-        formatter.write_str(
-            "an integer or float representing a unix timestamp, or an RFC3339 timestamp string",
-        )
+        formatter.write_str("an integer or float representing a unix timestamp")
     }
 
     fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
     where
         E: Error,
     {
-        Ok(ChronoDateTimeUtcUnixTimestampOrRFC3339(chrono::UTC.timestamp(v, 0)))
+        Ok(ChronoDateTimeUtcUnixTimestamp(chrono::UTC.timestamp(v, 0)))
     }
 
     fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
     where
         E: Error,
     {
-        Ok(ChronoDateTimeUtcUnixTimestampOrRFC3339(chrono::UTC.timestamp(v as i64, 0)))
+        Ok(ChronoDateTimeUtcUnixTimestamp(chrono::UTC.timestamp(v as i64, 0)))
     }
 
     fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
@@ -38,7 +36,7 @@ impl<'de> Visitor<'de> for SerdeChronoDateTimeUtcAsSecondsVisitor {
         E: Error,
     {
         let duration = std::time::Duration::from_secs_f32(v);
-        Ok(ChronoDateTimeUtcUnixTimestampOrRFC3339(
+        Ok(ChronoDateTimeUtcUnixTimestamp(
             chrono::UTC.timestamp(duration.as_secs() as i64, duration.subsec_nanos()),
         ))
     }
@@ -48,23 +46,13 @@ impl<'de> Visitor<'de> for SerdeChronoDateTimeUtcAsSecondsVisitor {
         E: Error,
     {
         let duration = std::time::Duration::from_secs_f64(v);
-        Ok(ChronoDateTimeUtcUnixTimestampOrRFC3339(
+        Ok(ChronoDateTimeUtcUnixTimestamp(
             chrono::UTC.timestamp(duration.as_secs() as i64, duration.subsec_nanos()),
         ))
     }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        match chrono::DateTime::parse_from_rfc3339(v) {
-            Ok(t) => Ok(ChronoDateTimeUtcUnixTimestampOrRFC3339(t.with_timezone(&chrono::UTC))),
-            Err(err) => Err(E::custom("Invalid timestamp format")),
-        }
-    }
 }
 
-impl<'de> Deserialize<'de> for ChronoDateTimeUtcUnixTimestampOrRFC3339 {
+impl<'de> Deserialize<'de> for ChronoDateTimeUtcUnixTimestamp {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -73,8 +61,8 @@ impl<'de> Deserialize<'de> for ChronoDateTimeUtcUnixTimestampOrRFC3339 {
     }
 }
 
-impl<'a> From<&'a ChronoDateTimeUtcUnixTimestampOrRFC3339> for chrono::DateTime<chrono::UTC> {
-    fn from(value: &'a ChronoDateTimeUtcUnixTimestampOrRFC3339) -> Self {
+impl<'a> From<&'a ChronoDateTimeUtcUnixTimestamp> for chrono::DateTime<chrono::UTC> {
+    fn from(value: &'a ChronoDateTimeUtcUnixTimestamp) -> Self {
         value.0
     }
 }

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -1,0 +1,144 @@
+#[cfg(feature = "time")]
+mod time_crate;
+
+#[cfg(feature = "time")]
+pub use self::time_crate::{SerdeTimeOffsetTimeAsSeconds};
+
+#[cfg(feature = "chrono")]
+mod chrono;
+
+#[cfg(feature = "chrono")]
+pub use self::chrono::{ChronoDateTimeUtcUnixTimestampOrRFC3339};
+
+use std::fmt::Formatter;
+use std::time::{Duration, SystemTime};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde::de::{Error, Visitor};
+
+/// Trait for getting the current time and comparing various JWT timestamps.
+pub trait JwtInstant: Sized {
+    /// Returns an instant corresponding to the current time.
+    fn now() -> Self;
+
+    /// Checks if the current instant is before the given instant.
+    fn is_before(&self, other: &Self) -> bool;
+
+    /// Checks if the current instant is after the given instant.
+    fn is_after(&self, other: &Self) -> bool;
+
+    /// Returns a new instant by adding the specified number of seconds to the current instant.
+    fn with_added_seconds(&self, seconds: u64) -> Self;
+}
+
+/// Deserializes [`std::time::SystemTime`] from a UNIX timestamp.
+///
+/// # Warning
+///
+/// This implementation assumes that the server's timezone is set to UTC. If your server's timezone
+/// is different, consider enabling and using the `time` or `chrono` features in this crate, which
+/// provide more comprehensive timezone handling.
+pub struct SerdeSystemTimeFromSeconds(SystemTime);
+
+struct SerdeSystemTimeAsSecondsVisitor;
+
+impl<'de> Visitor<'de> for SerdeSystemTimeAsSecondsVisitor {
+    type Value = SerdeSystemTimeFromSeconds;
+
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        formatter.write_str("an integer or float representing a unix timestamp")
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: Error {
+        Ok(SerdeSystemTimeFromSeconds(SystemTime::UNIX_EPOCH + Duration::from_secs(v)))
+    }
+
+    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E> where E: Error {
+        Ok(SerdeSystemTimeFromSeconds(SystemTime::UNIX_EPOCH + Duration::from_secs_f32(v)))
+    }
+
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E> where E: Error {
+        Ok(SerdeSystemTimeFromSeconds(SystemTime::UNIX_EPOCH + Duration::from_secs_f64(v)))
+    }
+}
+
+impl<'de> Deserialize<'de> for SerdeSystemTimeFromSeconds {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+        deserializer.deserialize_any(SerdeSystemTimeAsSecondsVisitor)
+    }
+}
+
+impl<'a> From<&'a SerdeSystemTimeFromSeconds> for SystemTime {
+    fn from(value: &'a SerdeSystemTimeFromSeconds) -> Self {
+        value.0
+    }
+}
+
+
+impl JwtInstant for SystemTime {
+    fn now() -> Self {
+        SystemTime::now()
+    }
+
+    fn is_before(&self, other: &Self) -> bool {
+        *self < *other
+    }
+
+    fn is_after(&self, other: &Self) -> bool {
+        *self > *other
+    }
+
+    fn with_added_seconds(&self, seconds: u64) -> Self {
+        *self + Duration::from_secs(seconds)
+    }
+}
+
+/// Specifies the types used for deserializing and comparing timestamps found in the JWTs
+pub trait TimestampOptions {
+    /// The type used to represent and compare timestamps
+    type Instant: JwtInstant + for<'a> From<&'a Self::InstantDeserializationWrapper>;
+    /// The type used to deserialize the timestamps from JSON
+    type InstantDeserializationWrapper: for<'de> Deserialize<'de>;
+}
+
+/// Uses [`std::time::SystemTime`] to to represent timestamps.
+#[cfg(not(any(feature = "default_time", feature = "default_chrono")))]
+pub type DefaultTimestampOptions = DefaultSystemTimeTimestampOptions;
+
+/// Uses [`::time::OffsetDateTime`] to to represent timestamps.
+#[cfg(feature = "default_time")]
+pub type DefaultTimestampOptions = TimeOffsetDateTimeTimestampOptions;
+
+/// Uses [`::chrono::DateTime::<::chrono::UTC>`] to to represent timestamps.
+#[cfg(feature = "default_chrono")]
+pub type DefaultTimestampOptions = ChronoDateTimeUtcTimestampOptions;
+
+/// Uses [`std::time::SystemTime`] to to represent timestamps.
+#[derive(Default)]
+pub struct DefaultSystemTimeTimestampOptions;
+
+impl TimestampOptions for DefaultSystemTimeTimestampOptions {
+    type Instant = SystemTime;
+    type InstantDeserializationWrapper = SerdeSystemTimeFromSeconds;
+}
+
+/// Uses [`time::OffsetDateTime`] to to represent timestamps.
+#[cfg(feature = "time")]
+#[derive(Default)]
+pub struct TimeOffsetDateTimeTimestampOptions;
+
+#[cfg(feature = "time")]
+impl TimestampOptions for TimeOffsetDateTimeTimestampOptions {
+    type Instant = time::OffsetDateTime;
+    type InstantDeserializationWrapper = crate::time::SerdeTimeOffsetTimeAsSeconds;
+}
+
+/// Uses [`chrono::DateTime::<chrono::UTC>`] to to represent timestamps.
+#[cfg(feature = "chrono")]
+#[derive(Default)]
+pub struct ChronoDateTimeUtcTimestampOptions;
+
+#[cfg(feature = "chrono")]
+impl TimestampOptions for ChronoDateTimeUtcTimestampOptions {
+    type Instant = ::chrono::DateTime<::chrono::UTC>;
+    type InstantDeserializationWrapper = crate::time::ChronoDateTimeUtcUnixTimestampOrRFC3339;
+}

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -2,18 +2,18 @@
 mod time_crate;
 
 #[cfg(feature = "time")]
-pub use self::time_crate::{SerdeTimeOffsetTimeAsSeconds};
+pub use self::time_crate::SerdeTimeOffsetTimeAsSeconds;
 
 #[cfg(feature = "chrono")]
 mod chrono;
 
 #[cfg(feature = "chrono")]
-pub use self::chrono::{ChronoDateTimeUtcUnixTimestampOrRFC3339};
+pub use self::chrono::ChronoDateTimeUtcUnixTimestampOrRFC3339;
 
+use serde::de::{Error, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt::Formatter;
 use std::time::{Duration, SystemTime};
-use serde::{Deserialize, Deserializer, Serialize};
-use serde::de::{Error, Visitor};
 
 /// Trait for getting the current time and comparing various JWT timestamps.
 pub trait JwtInstant: Sized {
@@ -48,21 +48,33 @@ impl<'de> Visitor<'de> for SerdeSystemTimeAsSecondsVisitor {
         formatter.write_str("an integer or float representing a unix timestamp")
     }
 
-    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: Error {
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
         Ok(SerdeSystemTimeFromSeconds(SystemTime::UNIX_EPOCH + Duration::from_secs(v)))
     }
 
-    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E> where E: Error {
+    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
         Ok(SerdeSystemTimeFromSeconds(SystemTime::UNIX_EPOCH + Duration::from_secs_f32(v)))
     }
 
-    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E> where E: Error {
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
         Ok(SerdeSystemTimeFromSeconds(SystemTime::UNIX_EPOCH + Duration::from_secs_f64(v)))
     }
 }
 
 impl<'de> Deserialize<'de> for SerdeSystemTimeFromSeconds {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
         deserializer.deserialize_any(SerdeSystemTimeAsSecondsVisitor)
     }
 }
@@ -72,7 +84,6 @@ impl<'a> From<&'a SerdeSystemTimeFromSeconds> for SystemTime {
         value.0
     }
 }
-
 
 impl JwtInstant for SystemTime {
     fn now() -> Self {

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -8,7 +8,7 @@ pub use self::time_crate::SerdeTimeOffsetTimeAsSeconds;
 mod chrono;
 
 #[cfg(feature = "chrono")]
-pub use self::chrono::ChronoDateTimeUtcUnixTimestampOrRFC3339;
+pub use self::chrono::ChronoDateTimeUtcUnixTimestamp;
 
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -151,5 +151,5 @@ pub struct ChronoDateTimeUtcTimestampOptions;
 #[cfg(feature = "chrono")]
 impl TimestampOptions for ChronoDateTimeUtcTimestampOptions {
     type Instant = ::chrono::DateTime<::chrono::UTC>;
-    type InstantDeserializationWrapper = crate::time::ChronoDateTimeUtcUnixTimestampOrRFC3339;
+    type InstantDeserializationWrapper = crate::time::ChronoDateTimeUtcUnixTimestamp;
 }

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -11,7 +11,7 @@ mod chrono;
 pub use self::chrono::ChronoDateTimeUtcUnixTimestamp;
 
 use serde::de::{Error, Visitor};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer};
 use std::fmt::Formatter;
 use std::time::{Duration, SystemTime};
 

--- a/src/time/time_crate.rs
+++ b/src/time/time_crate.rs
@@ -1,0 +1,104 @@
+use std::fmt::Formatter;
+use serde::de::{Error, Visitor};
+use serde::{Deserialize, Deserializer};
+use time::error::Parse;
+use time::format_description::well_known::{Iso8601, Rfc3339};
+use time::OffsetDateTime;
+use time::serde::iso8601;
+use crate::decoding::DecodingOptions;
+use crate::time::{JwtInstant};
+
+/// Deserializes [`time::OffsetDateTime`] from a UNIX timestamp, an ISO8601 timestamp, or an
+/// RFC3339 timestamp.
+pub struct SerdeTimeOffsetTimeAsSeconds(OffsetDateTime);
+
+struct SerdeTimeOffsetTimeAsSecondsVisitor;
+
+impl<'de> Visitor<'de> for SerdeTimeOffsetTimeAsSecondsVisitor {
+    type Value = SerdeTimeOffsetTimeAsSeconds;
+
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        formatter.write_str(
+            "an integer or float representing a unix timestamp, or an ISO timestamp string"
+        )
+    }
+
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: Error {
+        if let Ok(t) = OffsetDateTime::from_unix_timestamp(v) {
+            return Ok(SerdeTimeOffsetTimeAsSeconds(t));
+        } else {
+            return Err(E::custom("Couldn't unix timestamp to OffsetDateTime"));
+        }
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: Error {
+        if let Ok(t) = OffsetDateTime::from_unix_timestamp(v as i64) {
+            return Ok(SerdeTimeOffsetTimeAsSeconds(t));
+        } else {
+            return Err(E::custom("Couldn't unix timestamp to OffsetDateTime"));
+        }
+    }
+
+    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E> where E: Error {
+        if let Ok(t) = OffsetDateTime::from_unix_timestamp_nanos(
+            std::time::Duration::from_secs_f32(v).as_nanos() as i128
+        ) {
+            return Ok(SerdeTimeOffsetTimeAsSeconds(t));
+        } else {
+            return Err(E::custom("Couldn't unix timestamp to OffsetDateTime"));
+        }
+    }
+
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E> where E: Error {
+        if let Ok(t) = OffsetDateTime::from_unix_timestamp_nanos(
+            std::time::Duration::from_secs_f64(v).as_nanos() as i128
+        ) {
+            return Ok(SerdeTimeOffsetTimeAsSeconds(t));
+        } else {
+            return Err(E::custom("Couldn't unix timestamp to OffsetDateTime"));
+        }
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: Error {
+        if let Ok(t) = OffsetDateTime::parse(v, &Iso8601::DEFAULT) {
+            return Ok(SerdeTimeOffsetTimeAsSeconds(t));
+        }
+        match OffsetDateTime::parse(v, &Rfc3339) {
+            Ok(t) => Ok(SerdeTimeOffsetTimeAsSeconds(t)),
+            Err(err) => {
+                Err(E::custom("Invalid timestamp format"))
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SerdeTimeOffsetTimeAsSeconds {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+        deserializer.deserialize_any(SerdeTimeOffsetTimeAsSecondsVisitor)
+    }
+}
+
+impl<'a> From<&'a SerdeTimeOffsetTimeAsSeconds> for OffsetDateTime {
+    fn from(value: &'a SerdeTimeOffsetTimeAsSeconds) -> Self {
+        value.0
+    }
+}
+
+
+impl JwtInstant for OffsetDateTime {
+    fn now() -> Self {
+        OffsetDateTime::now_utc()
+    }
+
+    fn is_before(&self, other: &Self) -> bool {
+        *self < *other
+    }
+
+    fn is_after(&self, other: &Self) -> bool {
+        *self > *other
+    }
+
+    fn with_added_seconds(&self, seconds: u64) -> Self {
+        *self + time::Duration::seconds(seconds as i64)
+    }
+}

--- a/src/time/time_crate.rs
+++ b/src/time/time_crate.rs
@@ -1,12 +1,12 @@
-use std::fmt::Formatter;
+use crate::decoding::DecodingOptions;
+use crate::time::JwtInstant;
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer};
+use std::fmt::Formatter;
 use time::error::Parse;
 use time::format_description::well_known::{Iso8601, Rfc3339};
-use time::OffsetDateTime;
 use time::serde::iso8601;
-use crate::decoding::DecodingOptions;
-use crate::time::{JwtInstant};
+use time::OffsetDateTime;
 
 /// Deserializes [`time::OffsetDateTime`] from a UNIX timestamp, an ISO8601 timestamp, or an
 /// RFC3339 timestamp.
@@ -19,11 +19,14 @@ impl<'de> Visitor<'de> for SerdeTimeOffsetTimeAsSecondsVisitor {
 
     fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
         formatter.write_str(
-            "an integer or float representing a unix timestamp, or an ISO timestamp string"
+            "an integer or float representing a unix timestamp, or an ISO timestamp string",
         )
     }
 
-    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: Error {
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
         if let Ok(t) = OffsetDateTime::from_unix_timestamp(v) {
             return Ok(SerdeTimeOffsetTimeAsSeconds(t));
         } else {
@@ -31,7 +34,10 @@ impl<'de> Visitor<'de> for SerdeTimeOffsetTimeAsSecondsVisitor {
         }
     }
 
-    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: Error {
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
         if let Ok(t) = OffsetDateTime::from_unix_timestamp(v as i64) {
             return Ok(SerdeTimeOffsetTimeAsSeconds(t));
         } else {
@@ -39,9 +45,12 @@ impl<'de> Visitor<'de> for SerdeTimeOffsetTimeAsSecondsVisitor {
         }
     }
 
-    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E> where E: Error {
+    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
         if let Ok(t) = OffsetDateTime::from_unix_timestamp_nanos(
-            std::time::Duration::from_secs_f32(v).as_nanos() as i128
+            std::time::Duration::from_secs_f32(v).as_nanos() as i128,
         ) {
             return Ok(SerdeTimeOffsetTimeAsSeconds(t));
         } else {
@@ -49,9 +58,12 @@ impl<'de> Visitor<'de> for SerdeTimeOffsetTimeAsSecondsVisitor {
         }
     }
 
-    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E> where E: Error {
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
         if let Ok(t) = OffsetDateTime::from_unix_timestamp_nanos(
-            std::time::Duration::from_secs_f64(v).as_nanos() as i128
+            std::time::Duration::from_secs_f64(v).as_nanos() as i128,
         ) {
             return Ok(SerdeTimeOffsetTimeAsSeconds(t));
         } else {
@@ -59,21 +71,25 @@ impl<'de> Visitor<'de> for SerdeTimeOffsetTimeAsSecondsVisitor {
         }
     }
 
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: Error {
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
         if let Ok(t) = OffsetDateTime::parse(v, &Iso8601::DEFAULT) {
             return Ok(SerdeTimeOffsetTimeAsSeconds(t));
         }
         match OffsetDateTime::parse(v, &Rfc3339) {
             Ok(t) => Ok(SerdeTimeOffsetTimeAsSeconds(t)),
-            Err(err) => {
-                Err(E::custom("Invalid timestamp format"))
-            }
+            Err(err) => Err(E::custom("Invalid timestamp format")),
         }
     }
 }
 
 impl<'de> Deserialize<'de> for SerdeTimeOffsetTimeAsSeconds {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
         deserializer.deserialize_any(SerdeTimeOffsetTimeAsSecondsVisitor)
     }
 }
@@ -83,7 +99,6 @@ impl<'a> From<&'a SerdeTimeOffsetTimeAsSeconds> for OffsetDateTime {
         value.0
     }
 }
-
 
 impl JwtInstant for OffsetDateTime {
     fn now() -> Self {

--- a/src/time/time_crate.rs
+++ b/src/time/time_crate.rs
@@ -3,13 +3,9 @@ use crate::time::JwtInstant;
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer};
 use std::fmt::Formatter;
-use time::error::Parse;
-use time::format_description::well_known::{Iso8601, Rfc3339};
-use time::serde::iso8601;
 use time::OffsetDateTime;
 
-/// Deserializes [`time::OffsetDateTime`] from a UNIX timestamp, an ISO8601 timestamp, or an
-/// RFC3339 timestamp.
+/// Deserializes [`time::OffsetDateTime`] from a UNIX timestamp
 pub struct SerdeTimeOffsetTimeAsSeconds(OffsetDateTime);
 
 struct SerdeTimeOffsetTimeAsSecondsVisitor;
@@ -68,19 +64,6 @@ impl<'de> Visitor<'de> for SerdeTimeOffsetTimeAsSecondsVisitor {
             return Ok(SerdeTimeOffsetTimeAsSeconds(t));
         } else {
             return Err(E::custom("Couldn't unix timestamp to OffsetDateTime"));
-        }
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        if let Ok(t) = OffsetDateTime::parse(v, &Iso8601::DEFAULT) {
-            return Ok(SerdeTimeOffsetTimeAsSeconds(t));
-        }
-        match OffsetDateTime::parse(v, &Rfc3339) {
-            Ok(t) => Ok(SerdeTimeOffsetTimeAsSeconds(t)),
-            Err(err) => Err(E::custom("Invalid timestamp format")),
         }
     }
 }

--- a/src/time/time_crate.rs
+++ b/src/time/time_crate.rs
@@ -1,4 +1,3 @@
-use crate::decoding::DecodingOptions;
 use crate::time::JwtInstant;
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer};
@@ -19,38 +18,14 @@ impl<'de> Visitor<'de> for SerdeTimeOffsetTimeAsSecondsVisitor {
         )
     }
 
-    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        if let Ok(t) = OffsetDateTime::from_unix_timestamp(v) {
-            return Ok(SerdeTimeOffsetTimeAsSeconds(t));
-        } else {
-            return Err(E::custom("Couldn't unix timestamp to OffsetDateTime"));
-        }
-    }
-
     fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
     where
         E: Error,
     {
         if let Ok(t) = OffsetDateTime::from_unix_timestamp(v as i64) {
-            return Ok(SerdeTimeOffsetTimeAsSeconds(t));
+            Ok(SerdeTimeOffsetTimeAsSeconds(t))
         } else {
-            return Err(E::custom("Couldn't unix timestamp to OffsetDateTime"));
-        }
-    }
-
-    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        if let Ok(t) = OffsetDateTime::from_unix_timestamp_nanos(
-            std::time::Duration::from_secs_f32(v).as_nanos() as i128,
-        ) {
-            return Ok(SerdeTimeOffsetTimeAsSeconds(t));
-        } else {
-            return Err(E::custom("Couldn't unix timestamp to OffsetDateTime"));
+            Err(E::custom("Couldn't unix timestamp to OffsetDateTime"))
         }
     }
 
@@ -61,9 +36,9 @@ impl<'de> Visitor<'de> for SerdeTimeOffsetTimeAsSecondsVisitor {
         if let Ok(t) = OffsetDateTime::from_unix_timestamp_nanos(
             std::time::Duration::from_secs_f64(v).as_nanos() as i128,
         ) {
-            return Ok(SerdeTimeOffsetTimeAsSeconds(t));
+            Ok(SerdeTimeOffsetTimeAsSeconds(t))
         } else {
-            return Err(E::custom("Couldn't unix timestamp to OffsetDateTime"));
+            Err(E::custom("Couldn't unix timestamp to OffsetDateTime"))
         }
     }
 }


### PR DESCRIPTION
Should resolve timezone-related issues mentioned in #300 .

This PR introduces 4 new cargo features:

* `time`, which adds optional support for deserializing and comparing timestamps using `time` using `validate_with_options`.
* `chrono`, which adds optional support for deserializing and comparing timestamps using `chrono` using `validate_with_options`. 
* `default_time`, which makes `time` the default library used by `validate` to validate the tokens,
* `default_chrono`, which makes `chrono` the default library used by `chrono` to validate the tokens,

Therefore, the changes should, at least in theory, be backwards compatible, and fixing the time zone issue should be as simple as adding `default_time` or `default_chrono` to the list of cargo features.

However, this PR does make the `custom_time` example obsolete and it will have to be rewritten at some point. It still works fine from what I can tell, it's just not necessary because using a different type for timestamps is now as easy as copying and adapting the implementations in `jsonwebtoken::time`.