### PR TITLE
Upgrade pem from version 1 to 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde = {version = "1.0", features = ["derive"] }
 ring = { version = "0.16.5", features = ["std"] }
 base64 = "0.21.0"
 # For PEM decoding
-pem = {version = "1", optional = true}
+pem = {version = "2", optional = true}
 simple_asn1 = {version = "0.6", optional = true}
 
 [dev-dependencies]

--- a/src/pem/decoder.rs
+++ b/src/pem/decoder.rs
@@ -53,13 +53,13 @@ impl PemEncodedKey {
     pub fn new(input: &[u8]) -> Result<PemEncodedKey> {
         match pem::parse(input) {
             Ok(content) => {
-                let pem_contents = content.contents;
+                let pem_contents = content.contents().to_vec();
                 let asn1_content = match simple_asn1::from_der(pem_contents.as_slice()) {
                     Ok(asn1) => asn1,
                     Err(_) => return Err(ErrorKind::InvalidKeyFormat.into()),
                 };
 
-                match content.tag.as_ref() {
+                match content.tag().as_ref() {
                     // This handles a PKCS#1 RSA Private key
                     "RSA PRIVATE KEY" => Ok(PemEncodedKey {
                         content: pem_contents,


### PR DESCRIPTION
Upgrading `pem` crate from version `1` to `2` in order to get the latest `base64` crate version `0.21`