### PR TITLE
Pin regex version in dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ simple_asn1 = {version = "0.6", optional = true}
 # For the custom time example
 time = "0.3"
 criterion = "0.4"
+regex = "=1.7.3"
 
 [features]
 default = ["use_pem"]


### PR DESCRIPTION
Fix https://github.com/Keats/jsonwebtoken/issues/314

The regex v1.8.x needs the rustc 1.60.0 or newer, so we pins its version.