### PR TITLE
chore: update ring to 0.16.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.56.0"
 [dependencies]
 serde_json = "1.0"
 serde = {version = "1.0", features = ["derive"] }
-ring = { version = "0.16.5", features = ["std"] }
+ring = { version = "0.16.20", features = ["std"] }
 base64 = "0.21.0"
 # For PEM decoding
 pem = {version = "2", optional = true}


### PR DESCRIPTION
The older version of the `ring` dependency makes it impossible to use in projects with dependencies that use the current versions of `rustls` since cargo cannot satisfy the `ring` dependency for both.

`cargo test` passed locally

Tried looking through https://github.com/briansmith/ring for a changelog but didn't find anything.

I'm not sure if I missed something and there is a way to determine what the changes are. Going by the version numbers, it's patches so I _assumed_ it shoudn't be breaking changes. 