### PR TITLE
Do what chrono does

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,18 @@ rust-version = "1.67.0"
 [dependencies]
 serde_json = "1.0"
 serde = {version = "1.0", features = ["derive"] }
-ring = { version = "0.17.4", features = ["std", "wasm32_unknown_unknown_js"] }
 base64 = "0.21.0"
 # For PEM decoding
 pem = {version = "3", optional = true}
 simple_asn1 = {version = "0.6", optional = true}
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ring = { version = "0.17.4", features = ["std"] }
+
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"
+ring = { version = "0.17.4", features = ["std", "wasm32_unknown_unknown_js"] }
 
 [dev-dependencies]
 # For the custom time example

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,12 @@ rust-version = "1.67.0"
 [dependencies]
 serde_json = "1.0"
 serde = {version = "1.0", features = ["derive"] }
-ring = { version = "0.17.4", features = ["std"] }
+ring = { version = "0.17.4", features = ["std", "wasm32_unknown_unknown_js"] }
 base64 = "0.21.0"
 # For PEM decoding
 pem = {version = "3", optional = true}
 simple_asn1 = {version = "0.6", optional = true}
+js-sys = "0.3"
 
 [dev-dependencies]
 # For the custom time example

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 use std::fmt;
 use std::marker::PhantomData;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer};
@@ -137,9 +136,18 @@ impl Default for Validation {
 }
 
 /// Gets the current timestamp in the format expected by JWTs.
+#[cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))]
+#[must_use]
 pub fn get_current_timestamp() -> u64 {
-    let start = SystemTime::now();
-    start.duration_since(UNIX_EPOCH).expect("Time went backwards").as_secs()
+    let start = std::time::SystemTime::now();
+    start.duration_since(std::time::UNIX_EPOCH).expect("Time went backwards").as_secs()
+}
+
+/// Gets the current timestamp in the format expected by JWTs.
+#[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+#[must_use]
+pub fn get_current_timestamp() -> u64 {
+    js_sys::Date::new_0().get_time() as u64 / 1000
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
resolves #339 

I really don't like this approach though.

Why is setting the expiration time user controlled, but not validation? I have to import `chrono` so I can specify a timestamp for `exp`, but then the validation call is a black box that does something outside of user control. IMO, there shouldn't be a `get_current_timestamp` call. The user should have to supply one on calling `decode`, the same way they do when calling `encode`