### PR TITLE
Add wasm tests using was-bindgen-test and wasm-pack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Run tests default features
-        run: wasm-pack test --node --features "wasm"
+        run: wasm-pack test --node
 
       - name: Run tests no features
-        run: wasm-pack test --node --no-default-features --features "wasm"
+        run: wasm-pack test --node --no-default-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,11 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
+      - uses: actions/setup-node@v4
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+
       - name: Run tests default features
         run: wasm-pack test --node
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,19 +5,18 @@ on:
       - master
   pull_request:
 
-
 jobs:
   style:
     name: Format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt
-    - name: Check format
-      run: cargo fmt --check
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check format
+        run: cargo fmt --check
 
   clippy:
     name: Clippy
@@ -36,27 +35,43 @@ jobs:
       matrix:
         build: [pinned, stable, nightly]
         include:
-        - build: pinned
-          os: ubuntu-20.04
-          rust: 1.67.0
-        - build: stable
-          os: ubuntu-20.04
-          rust: stable
-        - build: nightly
-          os: ubuntu-20.04
-          rust: nightly
+          - build: pinned
+            os: ubuntu-20.04
+            rust: 1.67.0
+          - build: stable
+            os: ubuntu-20.04
+            rust: stable
+          - build: nightly
+            os: ubuntu-20.04
+            rust: nightly
     steps:
-    - uses: actions/checkout@v3
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ matrix.rust }}
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
 
-    - name: Build System Info
-      run: rustc --version
+      - name: Build System Info
+        run: rustc --version
 
-    - name: Run tests default features
-      run: cargo test
+      - name: Run tests default features
+        run: cargo test
 
-    - name: Run tests no features
-      run: cargo test --no-default-features
+      - name: Run tests no features
+        run: cargo test --no-default-features
+
+  wasm:
+    name: Run tests in wasm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Run tests default features
+        run: wasm-pack test --node --features "wasm"
+
+      - name: Run tests no features
+        run: wasm-pack test --node --no-default-features --features "wasm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,23 @@ homepage = "https://github.com/Keats/jsonwebtoken"
 repository = "https://github.com/Keats/jsonwebtoken"
 keywords = ["jwt", "api", "token", "jwk"]
 edition = "2021"
-include = ["src/**/*", "benches/**/*", "tests/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
+include = [
+    "src/**/*",
+    "benches/**/*",
+    "tests/**/*",
+    "LICENSE",
+    "README.md",
+    "CHANGELOG.md",
+]
 rust-version = "1.67.0"
 
 [dependencies]
 serde_json = "1.0"
-serde = {version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 base64 = "0.21.0"
 # For PEM decoding
-pem = {version = "3", optional = true}
-simple_asn1 = {version = "0.6", optional = true}
+pem = { version = "3", optional = true }
+simple_asn1 = { version = "0.6", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ring = { version = "0.17.4", features = ["std"] }
@@ -31,11 +38,20 @@ ring = { version = "0.17.4", features = ["std", "wasm32_unknown_unknown_js"] }
 [dev-dependencies]
 # For the custom time example
 time = "0.3"
+wasm-bindgen-test = "0.3.1"
+
+[target.'cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))'.dev-dependencies]
 criterion = "0.4"
+
+[target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]
+criterion = { version = "0.4", default-features = false }
 
 [features]
 default = ["use_pem"]
 use_pem = ["pem", "simple_asn1"]
+
+# Enable wasm support.
+wasm = ["time/wasm-bindgen", "ring/wasm32_unknown_unknown_js"]
 
 [[bench]]
 name = "jwt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,28 +30,26 @@ simple_asn1 = { version = "0.6", optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ring = { version = "0.17.4", features = ["std"] }
 
-
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"
 ring = { version = "0.17.4", features = ["std", "wasm32_unknown_unknown_js"] }
 
 [dev-dependencies]
-# For the custom time example
-time = "0.3"
 wasm-bindgen-test = "0.3.1"
 
 [target.'cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))'.dev-dependencies]
+# For the custom time example
+time = "0.3"
 criterion = "0.4"
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]
+# For the custom time example
+time = { version = "0.3", features = ["wasm-bindgen"] }
 criterion = { version = "0.4", default-features = false }
 
 [features]
 default = ["use_pem"]
 use_pem = ["pem", "simple_asn1"]
-
-# Enable wasm support.
-wasm = ["time/wasm-bindgen", "ring/wasm32_unknown_unknown_js"]
 
 [[bench]]
 name = "jwt"

--- a/examples/custom_header.rs
+++ b/examples/custom_header.rs
@@ -7,7 +7,7 @@ use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, 
 struct Claims {
     sub: String,
     company: String,
-    exp: usize,
+    exp: u64,
 }
 
 fn main() {

--- a/examples/validation.rs
+++ b/examples/validation.rs
@@ -7,7 +7,7 @@ struct Claims {
     aud: String,
     sub: String,
     company: String,
-    exp: usize,
+    exp: u64,
 }
 
 fn main() {

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -84,9 +84,12 @@ impl Algorithm {
 
 #[cfg(test)]
 mod tests {
+    use wasm_bindgen_test::wasm_bindgen_test;
+
     use super::*;
 
     #[test]
+    #[wasm_bindgen_test]
     fn generate_algorithm_enum_from_str() {
         assert!(Algorithm::from_str("HS256").is_ok());
         assert!(Algorithm::from_str("HS384").is_ok());

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -179,9 +179,12 @@ impl From<ErrorKind> for Error {
 
 #[cfg(test)]
 mod tests {
+    use wasm_bindgen_test::wasm_bindgen_test;
+
     use super::*;
 
     #[test]
+    #[wasm_bindgen_test]
     fn test_error_rendering() {
         assert_eq!(
             "InvalidAlgorithmName",

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -439,8 +439,10 @@ mod tests {
     use crate::serialization::b64_encode;
     use crate::Algorithm;
     use serde_json::json;
+    use wasm_bindgen_test::wasm_bindgen_test;
 
     #[test]
+    #[wasm_bindgen_test]
     fn check_hs256() {
         let key = b64_encode("abcdefghijklmnopqrstuvwxyz012345");
         let jwks_json = json!({

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -346,6 +346,7 @@ where
 #[cfg(test)]
 mod tests {
     use serde_json::json;
+    use wasm_bindgen_test::wasm_bindgen_test;
 
     use super::{get_current_timestamp, validate, ClaimsForValidation, Validation};
 
@@ -358,6 +359,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn exp_in_future_ok() {
         let claims = json!({ "exp": get_current_timestamp() + 10000 });
         let res = validate(deserialize_claims(&claims), &Validation::new(Algorithm::HS256));
@@ -365,6 +367,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn exp_float_in_future_ok() {
         let claims = json!({ "exp": (get_current_timestamp() as f64) + 10000.123 });
         let res = validate(deserialize_claims(&claims), &Validation::new(Algorithm::HS256));
@@ -372,6 +375,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn exp_in_past_fails() {
         let claims = json!({ "exp": get_current_timestamp() - 100000 });
         let res = validate(deserialize_claims(&claims), &Validation::new(Algorithm::HS256));
@@ -384,6 +388,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn exp_float_in_past_fails() {
         let claims = json!({ "exp": (get_current_timestamp() as f64) - 100000.1234 });
         let res = validate(deserialize_claims(&claims), &Validation::new(Algorithm::HS256));
@@ -396,6 +401,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn exp_in_past_but_in_leeway_ok() {
         let claims = json!({ "exp": get_current_timestamp() - 500 });
         let mut validation = Validation::new(Algorithm::HS256);
@@ -406,6 +412,7 @@ mod tests {
 
     // https://github.com/Keats/jsonwebtoken/issues/51
     #[test]
+    #[wasm_bindgen_test]
     fn validate_required_fields_are_present() {
         for spec_claim in ["exp", "nbf", "aud", "iss", "sub"] {
             let claims = json!({});
@@ -417,6 +424,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn exp_validated_but_not_required_ok() {
         let claims = json!({});
         let mut validation = Validation::new(Algorithm::HS256);
@@ -427,6 +435,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn exp_validated_but_not_required_fails() {
         let claims = json!({ "exp": (get_current_timestamp() as f64) - 100000.1234 });
         let mut validation = Validation::new(Algorithm::HS256);
@@ -437,6 +446,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn exp_required_but_not_validated_ok() {
         let claims = json!({ "exp": (get_current_timestamp() as f64) - 100000.1234 });
         let mut validation = Validation::new(Algorithm::HS256);
@@ -447,6 +457,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn exp_required_but_not_validated_fails() {
         let claims = json!({});
         let mut validation = Validation::new(Algorithm::HS256);
@@ -457,6 +468,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn nbf_in_past_ok() {
         let claims = json!({ "nbf": get_current_timestamp() - 10000 });
         let mut validation = Validation::new(Algorithm::HS256);
@@ -468,6 +480,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn nbf_float_in_past_ok() {
         let claims = json!({ "nbf": (get_current_timestamp() as f64) - 10000.1234 });
         let mut validation = Validation::new(Algorithm::HS256);
@@ -479,6 +492,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn nbf_in_future_fails() {
         let claims = json!({ "nbf": get_current_timestamp() + 100000 });
         let mut validation = Validation::new(Algorithm::HS256);
@@ -495,6 +509,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn nbf_in_future_but_in_leeway_ok() {
         let claims = json!({ "nbf": get_current_timestamp() + 500 });
         let mut validation = Validation::new(Algorithm::HS256);
@@ -507,6 +522,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn iss_string_ok() {
         let claims = json!({"iss": ["Keats"]});
         let mut validation = Validation::new(Algorithm::HS256);
@@ -518,6 +534,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn iss_array_of_string_ok() {
         let claims = json!({"iss": ["UserA", "UserB"]});
         let mut validation = Validation::new(Algorithm::HS256);
@@ -529,6 +546,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn iss_not_matching_fails() {
         let claims = json!({"iss": "Hacked"});
 
@@ -546,6 +564,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn iss_missing_fails() {
         let claims = json!({});
 
@@ -562,6 +581,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn sub_ok() {
         let claims = json!({"sub": "Keats"});
         let mut validation = Validation::new(Algorithm::HS256);
@@ -573,6 +593,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn sub_not_matching_fails() {
         let claims = json!({"sub": "Hacked"});
         let mut validation = Validation::new(Algorithm::HS256);
@@ -589,6 +610,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn sub_missing_fails() {
         let claims = json!({});
         let mut validation = Validation::new(Algorithm::HS256);
@@ -605,6 +627,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn aud_string_ok() {
         let claims = json!({"aud": "Everyone"});
         let mut validation = Validation::new(Algorithm::HS256);
@@ -616,6 +639,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn aud_array_of_string_ok() {
         let claims = json!({"aud": ["UserA", "UserB"]});
         let mut validation = Validation::new(Algorithm::HS256);
@@ -627,6 +651,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn aud_type_mismatch_fails() {
         let claims = json!({"aud": ["Everyone"]});
         let mut validation = Validation::new(Algorithm::HS256);
@@ -643,6 +668,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn aud_correct_type_not_matching_fails() {
         let claims = json!({"aud": ["Everyone"]});
         let mut validation = Validation::new(Algorithm::HS256);
@@ -659,6 +685,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn aud_none_fails() {
         let claims = json!({"aud": ["Everyone"]});
         let mut validation = Validation::new(Algorithm::HS256);
@@ -675,6 +702,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn aud_validation_skipped() {
         let claims = json!({"aud": ["Everyone"]});
         let mut validation = Validation::new(Algorithm::HS256);
@@ -687,6 +715,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn aud_missing_fails() {
         let claims = json!({});
         let mut validation = Validation::new(Algorithm::HS256);
@@ -704,6 +733,7 @@ mod tests {
 
     // https://github.com/Keats/jsonwebtoken/issues/51
     #[test]
+    #[wasm_bindgen_test]
     fn does_validation_in_right_order() {
         let claims = json!({ "exp": get_current_timestamp() + 10000 });
 
@@ -724,6 +754,7 @@ mod tests {
 
     // https://github.com/Keats/jsonwebtoken/issues/110
     #[test]
+    #[wasm_bindgen_test]
     fn aud_use_validation_struct() {
         let claims = json!({"aud": "my-googleclientid1234.apps.googleusercontent.com"});
 

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use jsonwebtoken::{decode, encode, Header, Validation};
 #[cfg(feature = "use_pem")]
 use time::OffsetDateTime;
+use wasm_bindgen_test::wasm_bindgen_test;
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Claims {
@@ -17,6 +18,7 @@ pub struct Claims {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn round_trip_sign_verification_pk8() {
     let privkey = include_bytes!("private_ecdsa_key.pk8");
     let pubkey = include_bytes!("public_ecdsa_key.pk8");
@@ -31,6 +33,7 @@ fn round_trip_sign_verification_pk8() {
 
 #[cfg(feature = "use_pem")]
 #[test]
+#[wasm_bindgen_test]
 fn round_trip_sign_verification_pem() {
     let privkey_pem = include_bytes!("private_ecdsa_key.pem");
     let pubkey_pem = include_bytes!("public_ecdsa_key.pem");
@@ -49,6 +52,7 @@ fn round_trip_sign_verification_pem() {
 
 #[cfg(feature = "use_pem")]
 #[test]
+#[wasm_bindgen_test]
 fn round_trip_claim() {
     let privkey_pem = include_bytes!("private_ecdsa_key.pem");
     let pubkey_pem = include_bytes!("public_ecdsa_key.pem");
@@ -74,6 +78,7 @@ fn round_trip_claim() {
 
 #[cfg(feature = "use_pem")]
 #[test]
+#[wasm_bindgen_test]
 fn ec_x_y() {
     let privkey = include_str!("private_ecdsa_key.pem");
     let my_claims = Claims {
@@ -100,6 +105,7 @@ fn ec_x_y() {
 
 #[cfg(feature = "use_pem")]
 #[test]
+#[wasm_bindgen_test]
 fn ed_jwk() {
     use jsonwebtoken::jwk::Jwk;
     use serde_json::json;
@@ -138,6 +144,7 @@ fn ed_jwk() {
 // https://jwt.io/ is often used for examples so ensure their example works with jsonwebtoken
 #[cfg(feature = "use_pem")]
 #[test]
+#[wasm_bindgen_test]
 fn roundtrip_with_jwtio_example() {
     // We currently do not support SEC1 so we use the converted PKCS8 formatted
     let privkey_pem = include_bytes!("private_jwtio_pkcs8.pem");

--- a/tests/eddsa/mod.rs
+++ b/tests/eddsa/mod.rs
@@ -3,6 +3,7 @@ use jsonwebtoken::{
     Algorithm, DecodingKey, EncodingKey,
 };
 use serde::{Deserialize, Serialize};
+use wasm_bindgen_test::wasm_bindgen_test;
 
 #[cfg(feature = "use_pem")]
 use jsonwebtoken::{decode, encode, Header, Validation};
@@ -17,6 +18,7 @@ pub struct Claims {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn round_trip_sign_verification_pk8() {
     let privkey = include_bytes!("private_ed25519_key.pk8");
     let pubkey = include_bytes!("public_ed25519_key.pk8");
@@ -31,6 +33,7 @@ fn round_trip_sign_verification_pk8() {
 
 #[cfg(feature = "use_pem")]
 #[test]
+#[wasm_bindgen_test]
 fn round_trip_sign_verification_pem() {
     let privkey_pem = include_bytes!("private_ed25519_key.pem");
     let pubkey_pem = include_bytes!("public_ed25519_key.pem");
@@ -49,6 +52,7 @@ fn round_trip_sign_verification_pem() {
 
 #[cfg(feature = "use_pem")]
 #[test]
+#[wasm_bindgen_test]
 fn round_trip_claim() {
     let privkey_pem = include_bytes!("private_ed25519_key.pem");
     let pubkey_pem = include_bytes!("public_ed25519_key.pem");
@@ -74,6 +78,7 @@ fn round_trip_claim() {
 
 #[cfg(feature = "use_pem")]
 #[test]
+#[wasm_bindgen_test]
 fn ed_x() {
     let privkey = include_str!("private_ed25519_key.pem");
     let my_claims = Claims {
@@ -99,6 +104,7 @@ fn ed_x() {
 
 #[cfg(feature = "use_pem")]
 #[test]
+#[wasm_bindgen_test]
 fn ed_jwk() {
     use jsonwebtoken::jwk::Jwk;
     use serde_json::json;

--- a/tests/header/mod.rs
+++ b/tests/header/mod.rs
@@ -1,9 +1,11 @@
 use base64::{engine::general_purpose::STANDARD, Engine};
 use jsonwebtoken::Header;
+use wasm_bindgen_test::wasm_bindgen_test;
 
 static CERT_CHAIN: [&str; 3] = include!("cert_chain.json");
 
 #[test]
+#[wasm_bindgen_test]
 fn x5c_der_empty_chain() {
     let header = Header { x5c: None, ..Default::default() };
     assert_eq!(header.x5c_der().unwrap(), None);
@@ -13,6 +15,7 @@ fn x5c_der_empty_chain() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn x5c_der_valid_chain() {
     let der_chain: Vec<Vec<u8>> =
         CERT_CHAIN.iter().map(|x| STANDARD.decode(x)).collect::<Result<_, _>>().unwrap();
@@ -24,6 +27,7 @@ fn x5c_der_valid_chain() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn x5c_der_invalid_chain() {
     let mut x5c: Vec<_> = CERT_CHAIN.iter().map(ToString::to_string).collect();
     x5c.push("invalid base64 data".to_string());

--- a/tests/hmac.rs
+++ b/tests/hmac.rs
@@ -6,6 +6,7 @@ use jsonwebtoken::{
 };
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
+use wasm_bindgen_test::wasm_bindgen_test;
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Claims {
@@ -15,6 +16,7 @@ pub struct Claims {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn sign_hs256() {
     let result =
         sign(b"hello world", &EncodingKey::from_secret(b"secret"), Algorithm::HS256).unwrap();
@@ -23,6 +25,7 @@ fn sign_hs256() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn verify_hs256() {
     let sig = "c0zGLzKEFWj0VxWuufTXiRMk5tlI5MbGDAYhzaxIYjo";
     let valid = verify(sig, b"hello world", &DecodingKey::from_secret(b"secret"), Algorithm::HS256)
@@ -31,6 +34,7 @@ fn verify_hs256() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn encode_with_custom_header() {
     let my_claims = Claims {
         sub: "b@b.com".to_string(),
@@ -50,6 +54,7 @@ fn encode_with_custom_header() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn round_trip_claim() {
     let my_claims = Claims {
         sub: "b@b.com".to_string(),
@@ -69,6 +74,7 @@ fn round_trip_claim() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn decode_token() {
     let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUiLCJleHAiOjI1MzI1MjQ4OTF9.9r56oF7ZliOBlOAyiOFperTGxBtPykRQiWNFxhDCW98";
     let claims = decode::<Claims>(
@@ -81,6 +87,7 @@ fn decode_token() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 #[should_panic(expected = "InvalidToken")]
 fn decode_token_missing_parts() {
     let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
@@ -93,6 +100,7 @@ fn decode_token_missing_parts() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 #[should_panic(expected = "InvalidSignature")]
 fn decode_token_invalid_signature() {
     let token =
@@ -106,6 +114,7 @@ fn decode_token_invalid_signature() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 #[should_panic(expected = "InvalidAlgorithm")]
 fn decode_token_wrong_algorithm() {
     let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUifQ.I1BvFoHe94AFf09O6tDbcSB8-jp8w6xZqmyHIwPeSdY";
@@ -118,6 +127,7 @@ fn decode_token_wrong_algorithm() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 #[should_panic(expected = "InvalidAlgorithm")]
 fn encode_wrong_alg_family() {
     let my_claims = Claims {
@@ -130,6 +140,7 @@ fn encode_wrong_alg_family() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn decode_token_with_bytes_secret() {
     let token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUiLCJleHAiOjI1MzI1MjQ4OTF9.Hm0yvKH25TavFPz7J_coST9lZFYH1hQo0tvhvImmaks";
     let claims = decode::<Claims>(
@@ -141,6 +152,7 @@ fn decode_token_with_bytes_secret() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn decode_header_only() {
     let token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJjb21wYW55IjoiMTIzNDU2Nzg5MCIsInN1YiI6IkpvaG4gRG9lIn0.S";
     let header = decode_header(token).unwrap();
@@ -149,6 +161,7 @@ fn decode_header_only() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn dangerous_insecure_decode_valid_token() {
     let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUiLCJleHAiOjI1MzI1MjQ4OTF9.9r56oF7ZliOBlOAyiOFperTGxBtPykRQiWNFxhDCW98";
     let mut validation = Validation::new(Algorithm::HS256);
@@ -158,6 +171,7 @@ fn dangerous_insecure_decode_valid_token() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn dangerous_insecure_decode_token_invalid_signature() {
     let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUiLCJleHAiOjI1MzI1MjQ4OTF9.wrong";
     let mut validation = Validation::new(Algorithm::HS256);
@@ -167,6 +181,7 @@ fn dangerous_insecure_decode_token_invalid_signature() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn dangerous_insecure_decode_token_wrong_algorithm() {
     let token = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUiLCJleHAiOjI1MzI1MjQ4OTF9.fLxey-hxAKX5rNHHIx1_Ch0KmrbiuoakDVbsJjLWrx8fbjKjrPuWMYEJzTU3SBnYgnZokC-wqSdqckXUOunC-g";
     let mut validation = Validation::new(Algorithm::HS256);
@@ -176,6 +191,7 @@ fn dangerous_insecure_decode_token_wrong_algorithm() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn dangerous_insecure_decode_token_with_validation_wrong_algorithm() {
     let token = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiQGIuY29tIiwiY29tcGFueSI6IkFDTUUiLCJleHAiOjk1MzI1MjQ4OX0.ONtEUTtP1QmyksYH9ijtPCaXoHjZVHcHKZGX1DuJyPiSyKlT93Y-oKgrp_OSkHSu4huxCcVObLzwsdwF-xwiAQ";
     let mut validation = Validation::new(Algorithm::HS256);
@@ -186,6 +202,7 @@ fn dangerous_insecure_decode_token_with_validation_wrong_algorithm() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn verify_hs256_rfc7517_appendix_a1() {
     #[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
     struct C {

--- a/tests/rsa/mod.rs
+++ b/tests/rsa/mod.rs
@@ -3,6 +3,7 @@ use jsonwebtoken::{
     Algorithm, DecodingKey, EncodingKey,
 };
 use serde::{Deserialize, Serialize};
+use wasm_bindgen_test::wasm_bindgen_test;
 
 #[cfg(feature = "use_pem")]
 use jsonwebtoken::{decode, encode, Header, Validation};
@@ -27,7 +28,9 @@ pub struct Claims {
 
 #[cfg(feature = "use_pem")]
 #[test]
+#[wasm_bindgen_test]
 fn round_trip_sign_verification_pem_pkcs1() {
+
     let privkey_pem = include_bytes!("private_rsa_key_pkcs1.pem");
     let pubkey_pem = include_bytes!("public_rsa_key_pkcs1.pem");
     let certificate_pem = include_bytes!("certificate_rsa_key_pkcs1.crt");
@@ -58,6 +61,7 @@ fn round_trip_sign_verification_pem_pkcs1() {
 
 #[cfg(feature = "use_pem")]
 #[test]
+#[wasm_bindgen_test]
 fn round_trip_sign_verification_pem_pkcs8() {
     let privkey_pem = include_bytes!("private_rsa_key_pkcs8.pem");
     let pubkey_pem = include_bytes!("public_rsa_key_pkcs8.pem");
@@ -88,6 +92,7 @@ fn round_trip_sign_verification_pem_pkcs8() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn round_trip_sign_verification_der() {
     let privkey_der = include_bytes!("private_rsa_key.der");
     let pubkey_der = include_bytes!("public_rsa_key.der");
@@ -103,6 +108,7 @@ fn round_trip_sign_verification_der() {
 
 #[cfg(feature = "use_pem")]
 #[test]
+#[wasm_bindgen_test]
 fn round_trip_claim() {
     let my_claims = Claims {
         sub: "b@b.com".to_string(),
@@ -139,6 +145,7 @@ fn round_trip_claim() {
 
 #[cfg(feature = "use_pem")]
 #[test]
+#[wasm_bindgen_test]
 fn rsa_modulus_exponent() {
     let privkey = include_str!("private_rsa_key_pkcs1.pem");
     let my_claims = Claims {
@@ -165,6 +172,7 @@ fn rsa_modulus_exponent() {
 
 #[cfg(feature = "use_pem")]
 #[test]
+#[wasm_bindgen_test]
 fn rsa_jwk() {
     use jsonwebtoken::jwk::Jwk;
     use serde_json::json;
@@ -201,6 +209,7 @@ fn rsa_jwk() {
 // https://jwt.io/ is often used for examples so ensure their example works with jsonwebtoken
 #[cfg(feature = "use_pem")]
 #[test]
+#[wasm_bindgen_test]
 fn roundtrip_with_jwtio_example_jey() {
     let privkey_pem = include_bytes!("private_jwtio.pem");
     let pubkey_pem = include_bytes!("public_jwtio.pem");

--- a/tests/rsa/mod.rs
+++ b/tests/rsa/mod.rs
@@ -30,7 +30,6 @@ pub struct Claims {
 #[test]
 #[wasm_bindgen_test]
 fn round_trip_sign_verification_pem_pkcs1() {
-
     let privkey_pem = include_bytes!("private_rsa_key_pkcs1.pem");
     let pubkey_pem = include_bytes!("public_rsa_key_pkcs1.pem");
     let certificate_pem = include_bytes!("certificate_rsa_key_pkcs1.crt");


### PR DESCRIPTION
A few notes:

1) Wasm32 related tests cannot be run that easily, see https://github.com/rustwasm/team/issues/173. You have to use https://rustwasm.github.io/wasm-bindgen/wasm-bindgen-test/usage.html and `wasm-pack`.

2) The `criterion` dev-dependency, only used for benchmarks, prohibits any compilation to the wasm32 target when using its default features (rayon in particular). This is now dependant on the targeted architecture.

3) Examples could not be compiled to wasm32, or any 32 bit target. The `Claims` struct from both `custom_hader.rs` and `validation.rs` had a `usize` field which got initialized with a value outside the u32 (usize on wasm32) range. Switching to an explicit u64 type in these structs seemed to be a reasonable fix?

4) Most crates provide some `wasm-...` feature, to enable wasm support. This crate uses `[target.'cfg(target_arch = "wasm32")'.dependencies]` inside its Cargo.toml. This is obviously easier for users, as there is no feature which could be forgotten. Are there any downsides to this method?

5) CI will most likely still not work, as 
  - nodejs must be installed
	https://github.com/nodesource/distributions/blob/master/README.md#ubuntu-versions
  - wasm-pack must be installed
	`cargo install wasm-pack`


Example `wasm-pack` output:
```
lukas@[...]:~/dev/jsonwebtoken$ wasm-pack test --node
[INFO]: 🎯  Checking for the Wasm target...
   Compiling jsonwebtoken v9.1.0 (/home/lukas/dev/jsonwebtoken)
    Finished dev [unoptimized + debuginfo] target(s) in 0.84s
   Compiling jsonwebtoken v9.1.0 (/home/lukas/dev/jsonwebtoken)
    Finished test [unoptimized + debuginfo] target(s) in 0.28s
     Running unittests src/lib.rs (target/wasm32-unknown-unknown/debug/deps/jsonwebtoken-ae8fe4284f1b721f.wasm)
no tests to run!
     Running tests/hmac.rs (target/wasm32-unknown-unknown/debug/deps/hmac-14855738297bd30c.wasm)
no tests to run!
     Running tests/lib.rs (target/wasm32-unknown-unknown/debug/deps/lib-17a50cd144c5e104.wasm)
Set timeout to 20 seconds...
running 21 tests                                  

test lib::ecdsa::roundtrip_with_jwtio_example ... ok
test lib::ecdsa::ed_jwk ... ok
test lib::ecdsa::ec_x_y ... ok
test lib::ecdsa::round_trip_claim ... ok
test lib::ecdsa::round_trip_sign_verification_pem ... ok
test lib::ecdsa::round_trip_sign_verification_pk8 ... ok
test lib::rsa::roundtrip_with_jwtio_example_jey ... ok
test lib::rsa::rsa_jwk ... ok
test lib::rsa::rsa_modulus_exponent ... ok
test lib::rsa::round_trip_claim ... ok
test lib::rsa::round_trip_sign_verification_der ... ok
test lib::rsa::round_trip_sign_verification_pem_pkcs8 ... ok
test lib::rsa::round_trip_sign_verification_pem_pkcs1 ... ok
test lib::eddsa::ed_jwk ... ok
test lib::eddsa::ed_x ... ok
test lib::eddsa::round_trip_claim ... ok
test lib::eddsa::round_trip_sign_verification_pem ... ok
test lib::eddsa::round_trip_sign_verification_pk8 ... ok
test lib::header::x5c_der_invalid_chain ... ok
test lib::header::x5c_der_valid_chain ... ok
test lib::header::x5c_der_empty_chain ... ok

test result: ok. 21 passed; 0 failed; 0 ignored
```