### PR TITLE
Set expected audience to validation in auth0 example

### DIFF
--- a/examples/auth0.rs
+++ b/examples/auth0.rs
@@ -27,6 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     Algorithm::from_str(j.common.key_algorithm.unwrap().to_string().as_str())
                         .unwrap(),
                 );
+                validation.set_audience(&["https://dev-duzyayk4.eu.auth0.com/api/v2/"]);
                 validation.validate_exp = false;
                 let decoded_token =
                     decode::<HashMap<String, serde_json::Value>>(TOKEN, &decoding_key, &validation)


### PR DESCRIPTION
The expected audience seems to be required as there is `aud` in the token.