### PR TITLE
Treat empty audience as equivalent to no audience

### DIFF
--- a/src/validation.rs
+++ b/src/validation.rs
@@ -286,6 +286,11 @@ pub(crate) fn validate(claims: ClaimsForValidation, options: &Validation) -> Res
         // processing the claim does not identify itself with a value in the
         // "aud" claim when this claim is present, then the JWT MUST be
         //  rejected.
+        (TryParse::Parsed(Audience::Multiple(aud)), None) => {
+            if !aud.is_empty() {
+                return Err(new_error(ErrorKind::InvalidAudience));
+            }
+        }
         (TryParse::Parsed(_), None) => {
             return Err(new_error(ErrorKind::InvalidAudience));
         }


### PR DESCRIPTION
Hello, 

There's a specific case where audience is supplied but empty, which I think should be treated as the same as audience not being supplied.

Ie:

```json
{
    "iss": ...,
    "aud": [],
    "exp": ...
    ...
}
```
Will fail validation if `options.aud` is `None`.
While (no aud)
```json
{
    "iss": ...,
    "exp": ...
    ...
}
```

passes validation in that same case where `options.aud` is `None`.

The user could just turn off audience validation, but the default is audience validation on, which is reasonable, but then it should accept the supplied but empty audience.

This could also be fixed by changing the deserialization, an empty vec gets deserialized into `Multiple` but it could be deserialized into `NotPresent`, but that is a bit trickier.