### PR TITLE
Make family public

### DIFF
--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -11,6 +11,7 @@ pub enum AlgorithmFamily {
 }
 
 impl AlgorithmFamily {
+    /// A list of all possible Algorithms that are part of the family.
     pub fn algorithms(&self) -> &[Algorithm] {
         match self {
             Self::Hmac => &[Algorithm::HS256, Algorithm::HS384, Algorithm::HS512],

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -3,11 +3,22 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize, Deserialize)]
-pub(crate) enum AlgorithmFamily {
+pub enum AlgorithmFamily {
     Hmac,
     Rsa,
     Ec,
     Ed,
+}
+
+impl AlgorithmFamily {
+    pub fn algorithms(&self) -> &[Algorithm] {
+        match self {
+            Self::Hmac => &[Algorithm::HS256, Algorithm::HS384, Algorithm::HS512],
+            Self::Rsa => &[Algorithm::RS256, Algorithm::RS384, Algorithm::RS512, Algorithm::PS256, Algorithm::PS384, Algorithm::PS384, Algorithm::PS512],
+            Self::Ec => &[Algorithm::ES256, Algorithm::ES384],
+            Self::Ed => &[Algorithm::EdDSA],
+        }
+    }
 }
 
 /// The algorithms supported for signing/verifying JWTs

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -14,12 +14,22 @@ impl AlgorithmFamily {
     pub fn algorithms(&self) -> &[Algorithm] {
         match self {
             Self::Hmac => &[Algorithm::HS256, Algorithm::HS384, Algorithm::HS512],
-            Self::Rsa => &[Algorithm::RS256, Algorithm::RS384, Algorithm::RS512, Algorithm::PS256, Algorithm::PS384, Algorithm::PS384, Algorithm::PS512],
+            Self::Rsa => &[
+                Algorithm::RS256,
+                Algorithm::RS384,
+                Algorithm::RS512,
+                Algorithm::PS256,
+                Algorithm::PS384,
+                Algorithm::PS384,
+                Algorithm::PS512,
+            ],
             Self::Ec => &[Algorithm::ES256, Algorithm::ES384],
             Self::Ed => &[Algorithm::EdDSA],
         }
     }
 }
+
+
 
 /// The algorithms supported for signing/verifying JWTs
 #[allow(clippy::upper_case_acronyms)]

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -56,6 +56,7 @@ pub struct DecodingKey {
 }
 
 impl DecodingKey {
+    /// The algorithm family this key is for.
     pub fn family(&self) -> AlgorithmFamily {
         self.family
     }

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -56,6 +56,10 @@ pub struct DecodingKey {
 }
 
 impl DecodingKey {
+    pub fn family(&self) -> AlgorithmFamily {
+        self.family
+    }
+    
     /// If you're using HMAC, use this.
     pub fn from_secret(secret: &[u8]) -> Self {
         DecodingKey {

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -18,6 +18,7 @@ pub struct EncodingKey {
 }
 
 impl EncodingKey {
+    /// The algorithm family this key is for.
     pub fn family(&self) -> AlgorithmFamily {
         self.family
     }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -18,6 +18,10 @@ pub struct EncodingKey {
 }
 
 impl EncodingKey {
+    pub fn family(&self) -> AlgorithmFamily {
+        self.family
+    }
+    
     /// If you're using a HMAC secret that is not base64, use that.
     pub fn from_secret(secret: &[u8]) -> Self {
         EncodingKey { family: AlgorithmFamily::Hmac, content: secret.to_vec() }


### PR DESCRIPTION
A patch to hopefully fix all the AlgorithmFamily confusion. We ran into a very similar issue which i think are many describing here. But i noticed that _we_ specifically like to pin the validation of the jwt to the decoding/encoding key that is being used. But unfortunately this is currently not possible without adding more state tracking for our keys, which is annoying given that they already store this information. 

This patch will publicize a method to get the `AlgorithmFamily` from both encoding & decoding key. And also adds a method to AlgorithmFamily  that will return a list of all algorithms which are part of the family