### PR TITLE
Add support for JWK thumbprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ let token = decode::<Claims>(&token, &DecodingKey::from_rsa_components(jwk["n"],
 If your key is in PEM format, it is better performance wise to generate the `DecodingKey` once in a `lazy_static` or
 something similar and reuse it.
 
+### JWK Thumbprints
+
+If you have a JWK object, you can generate a thumbprint like
+
+```
+let tp = my_jwk.thumbprint(&jsonwebtoken::DIGEST_SHA256);
+```
+
 ### Convert SEC1 private key to PKCS8
 `jsonwebtoken` currently only supports PKCS8 format for private EC keys. If your key has `BEGIN EC PRIVATE KEY` at the top,
 this is a SEC1 type and can be converted to PKCS8 like so:

--- a/README.md
+++ b/README.md
@@ -146,6 +146,20 @@ let token = decode::<Claims>(&token, &DecodingKey::from_rsa_components(jwk["n"],
 If your key is in PEM format, it is better performance wise to generate the `DecodingKey` once in a `lazy_static` or
 something similar and reuse it.
 
+### Encoding and decoding JWS
+
+JWS is handled the same way as JWT, but using `encode_jws` and `decode_jws`:
+
+```rust
+let encoded = encode_jws(&Header::default(), &my_claims, &EncodingKey::from_secret("secret".as_ref()))?;
+my_claims = decode_jws(&encoded, &DecodingKey::from_secret("secret".as_ref()), &Validation::default())?.claims;
+```
+
+`encode_jws` returns a `Jws<C>` struct which can be placed in other structs or serialized/deserialized from JSON directly.
+
+The generic parameter in `Jws<C>` indicates the claims type and prevents accidentally encoding or decoding the wrong claims type
+when the Jws is nested in another struct.
+
 ### JWK Thumbprints
 
 If you have a JWK object, you can generate a thumbprint like

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,12 +1,108 @@
 use std::result;
 
 use base64::{engine::general_purpose::STANDARD, Engine};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::algorithms::Algorithm;
 use crate::errors::Result;
 use crate::jwk::Jwk;
 use crate::serialization::b64_decode;
+
+const ZIP_SERIAL_DEFLATE: &str = "DEF";
+const ENC_A128CBC_HS256: &str = "A128CBC-HS256";
+const ENC_A192CBC_HS384: &str = "A192CBC-HS384";
+const ENC_A256CBC_HS512: &str = "A256CBC-HS512";
+const ENC_A128GCM: &str = "A128GCM";
+const ENC_A192GCM: &str = "A192GCM";
+const ENC_A256GCM: &str = "A256GCM";
+
+/// Encryption algorithm for encrypted payloads.
+///
+/// Defined in [RFC7516#4.1.2](https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.2).
+///
+/// Values defined in [RFC7518#5.1](https://datatracker.ietf.org/doc/html/rfc7518#section-5.1).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[allow(clippy::upper_case_acronyms, non_camel_case_types)]
+pub enum Enc {
+    A128CBC_HS256,
+    A192CBC_HS384,
+    A256CBC_HS512,
+    A128GCM,
+    A192GCM,
+    A256GCM,
+    Other(String),
+}
+
+impl Serialize for Enc {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Enc::A128CBC_HS256 => ENC_A128CBC_HS256,
+            Enc::A192CBC_HS384 => ENC_A192CBC_HS384,
+            Enc::A256CBC_HS512 => ENC_A256CBC_HS512,
+            Enc::A128GCM => ENC_A128GCM,
+            Enc::A192GCM => ENC_A192GCM,
+            Enc::A256GCM => ENC_A256GCM,
+            Enc::Other(v) => v,
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Enc {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            ENC_A128CBC_HS256 => return Ok(Enc::A128CBC_HS256),
+            ENC_A192CBC_HS384 => return Ok(Enc::A192CBC_HS384),
+            ENC_A256CBC_HS512 => return Ok(Enc::A256CBC_HS512),
+            ENC_A128GCM => return Ok(Enc::A128GCM),
+            ENC_A192GCM => return Ok(Enc::A192GCM),
+            ENC_A256GCM => return Ok(Enc::A256GCM),
+            _ => (),
+        }
+        Ok(Enc::Other(s))
+    }
+}
+/// Compression applied to plaintext.
+///
+/// Defined in [RFC7516#4.1.3](https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.3).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Zip {
+    Deflate,
+    Other(String),
+}
+
+impl Serialize for Zip {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Zip::Deflate => ZIP_SERIAL_DEFLATE,
+            Zip::Other(v) => v,
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Zip {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            ZIP_SERIAL_DEFLATE => Ok(Zip::Deflate),
+            _ => Ok(Zip::Other(s)),
+        }
+    }
+}
 
 /// A basic JWT header, the alg defaults to HS256 and typ is automatically
 /// set to `JWT`. All the other fields are optional.
@@ -64,6 +160,27 @@ pub struct Header {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "x5t#S256")]
     pub x5t_s256: Option<String>,
+    /// Critical - indicates header fields that must be understood by the receiver.
+    ///
+    /// Defined in [RFC7515#4.1.6](https://tools.ietf.org/html/rfc7515#section-4.1.6).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub crit: Option<Vec<String>>,
+    /// See `Enc` for description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enc: Option<Enc>,
+    /// See `Zip` for description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zip: Option<Zip>,
+    /// ACME: The URL to which this JWS object is directed
+    ///
+    /// Defined in [RFC8555#6.4](https://datatracker.ietf.org/doc/html/rfc8555#section-6.4).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// ACME: Random data for preventing replay attacks.
+    ///
+    /// Defined in [RFC8555#6.5.2](https://datatracker.ietf.org/doc/html/rfc8555#section-6.5.2).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<String>,
 }
 
 impl Header {
@@ -80,6 +197,11 @@ impl Header {
             x5c: None,
             x5t: None,
             x5t_s256: None,
+            crit: None,
+            enc: None,
+            zip: None,
+            url: None,
+            nonce: None,
         }
     }
 

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -407,7 +407,7 @@ pub enum AlgorithmParameters {
 pub enum ThumbprintHash {
     SHA256,
     SHA384,
-    SHA512
+    SHA512,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
@@ -497,7 +497,9 @@ impl JwkSet {
 
 #[cfg(test)]
 mod tests {
-    use crate::jwk::{AlgorithmParameters, Jwk, JwkSet, OctetKeyType, RSAKeyParameters, ThumbprintHash};
+    use crate::jwk::{
+        AlgorithmParameters, Jwk, JwkSet, OctetKeyType, RSAKeyParameters, ThumbprintHash,
+    };
     use crate::serialization::b64_encode;
     use crate::Algorithm;
     use serde_json::json;

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -1,0 +1,24 @@
+//! JSON Web Signatures data type.
+use std::marker::PhantomData;
+
+use serde::{Deserialize, Serialize};
+
+/// This is a serde-compatible JSON Web Signature structure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Jws<C> {
+    /// The base64 encoded header data.
+    ///
+    /// Defined in [RFC7515#3.2](https://tools.ietf.org/html/rfc7515#section-3.2).
+    pub protected: String,
+    /// The base64 encoded claims data.
+    ///
+    /// Defined in [RFC7515#3.2](https://tools.ietf.org/html/rfc7515#section-3.2).
+    pub payload: String,
+    /// The signature on the other fields.
+    ///
+    /// Defined in [RFC7515#3.2](https://tools.ietf.org/html/rfc7515#section-3.2).
+    pub signature: String,
+    /// Unused, for associating type metadata.
+    #[serde(skip)]
+    pub _pd: PhantomData<C>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,7 @@ pub use decoding::{decode, decode_header, DecodingKey, TokenData};
 pub use encoding::{encode, EncodingKey};
 pub use header::Header;
 pub use validation::{get_current_timestamp, Validation};
+
+pub use ring::digest::SHA256 as DIGEST_SHA256;
+pub use ring::digest::SHA384 as DIGEST_SHA384;
+pub use ring::digest::SHA512 as DIGEST_SHA512;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,13 +12,14 @@ mod encoding;
 pub mod errors;
 mod header;
 pub mod jwk;
+pub mod jws;
 #[cfg(feature = "use_pem")]
 mod pem;
 mod serialization;
 mod validation;
 
 pub use algorithms::Algorithm;
-pub use decoding::{decode, decode_header, DecodingKey, TokenData};
-pub use encoding::{encode, EncodingKey};
+pub use decoding::{decode, decode_header, decode_jws, DecodingKey, TokenData};
+pub use encoding::{encode, encode_jws, EncodingKey};
 pub use header::Header;
 pub use validation::{get_current_timestamp, Validation};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,3 @@ pub use decoding::{decode, decode_header, DecodingKey, TokenData};
 pub use encoding::{encode, EncodingKey};
 pub use header::Header;
 pub use validation::{get_current_timestamp, Validation};
-
-pub use ring::digest::SHA256 as DIGEST_SHA256;
-pub use ring::digest::SHA384 as DIGEST_SHA384;
-pub use ring::digest::SHA512 as DIGEST_SHA512;


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc7638

I republished the ring digests so that the feature could be used without matching ring versions.

The thumbprint json is hardcoded templates because I'm not sure if serde_json guarantees json string format (ordering, spacing, etc). The spec is written in such a way that quotation marks and backslashes won't appear in the serialized values so there's no risk of escape issues.

I think the readme's getting a bit crowded, but  I didn't want to introduce unrelated changes here so I didn't touch it.

Aside from the unit test, I was testing with letsencrypt/pebble with EC keys and it seemed to be okay (although I switched from serde_json to hardcoded string templates after that).