### PR TITLE
Update MSRV in README.md to match Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ jsonwebtoken = "9"
 serde = {version = "1.0", features = ["derive"] }
 ```
 
-The minimum required Rust version (MSRV) is 1.67.
+The minimum required Rust version (MSRV) is 1.73.
 
 ## Algorithms
 This library currently supports the following:


### PR DESCRIPTION
Fix the readme to match the required Rust version (MSRV) in Cargo.toml.