### PR TITLE
docs: remove errenous backtick from rsa tests

### DIFF
--- a/tests/rsa/README.md
+++ b/tests/rsa/README.md
@@ -14,7 +14,7 @@ openssl x509 -req -sha256 -days 358000 -in certificate_rsa_pkcs1.csr -signkey pr
 ### RSA PKCS8
 
 ```
-openssl genpkey -algorithm RSA -out private_rsa_pkcs8.pem -pkeyopt rsa_keygen_bits:2048`
+openssl genpkey -algorithm RSA -out private_rsa_pkcs8.pem -pkeyopt rsa_keygen_bits:2048
 openssl rsa -pubout -in private_rsa_pkcs8.pem -out public_rsa_pkcs.pem
 openssl req -new -key private_rsa_pkcs8.key -out certificate_rsa_pkcs8.csr
 openssl x509 -req -sha256 -days 358000 -in certificate_rsa_pkcs8.csr -signkey private_rsa_pkcs8.key -out certificate_rsa_pkcs8.crt


### PR DESCRIPTION
Small fix to the docs here.

I was trying to use the same parameters this library uses for my own test keys and noticed there was a backtick here which stops an easy copy-paste.
