### PR TITLE
Update header.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
+## 9.4.0 (2024-05-12)
 
+- Add id field to header struct
+  
 ## 9.3.0 (2024-03-12)
 
 - Add `Validation.reject_tokens_expiring_in_less_than`, the opposite of leeway

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsonwebtoken"
-version = "9.3.0"
-authors = ["Vincent Prouillet <hello@vincentprouillet.com>"]
+version = "9.4.0"
+authors = ["Vincent Prouillet <hello@vincentprouillet.com>", "Brandon Taylor <brandontaylor42@gmail.com"]
 license = "MIT"
 readme = "README.md"
 description = "Create and decode JWTs in a strongly typed way."

--- a/src/header.rs
+++ b/src/header.rs
@@ -64,6 +64,9 @@ pub struct Header {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "x5t#S256")]
     pub x5t_s256: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
 }
 
 impl Header {

--- a/src/header.rs
+++ b/src/header.rs
@@ -64,7 +64,9 @@ pub struct Header {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "x5t#S256")]
     pub x5t_s256: Option<String>,
-
+    /// Used by Apple WeatherKit
+    ///
+    /// Defined in https://developer.apple.com/documentation/weatherkitrestapi/request_authentication_for_weatherkit_rest_api.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 }
@@ -73,6 +75,7 @@ impl Header {
     /// Returns a JWT header with the algorithm given
     pub fn new(algorithm: Algorithm) -> Self {
         Header {
+            id: None,
             typ: Some("JWT".to_string()),
             alg: algorithm,
             cty: None,


### PR DESCRIPTION
add id to header struct to support WeatherKit JWT
https://developer.apple.com/documentation/weatherkitrestapi/request_authentication_for_weatherkit_rest_api
WeatherKit supports the JSON Web Token (JWT) specification, and allows you to pass statements and metadata called claims. For more information about JWT, see the [JWT specification](https://datatracker.ietf.org/doc/html/rfc7519). There are a variety of open source libraries available online for creating and signing JWT tokens. See [JWT.io](https://jwt.io/) for more information.

Construct a developer token as a JSON object with a header that contains the following information:

alg
The algorithm with which to sign the token. Set the value to ES256.

kid
A 10-character key identifier you obtain from your developer account.

id
An identifier that consists of your 10-character Team ID and Service ID, separated by a period.