### PR TITLE
fix: implement hash for JwkSet

### DIFF
--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -419,7 +419,7 @@ impl Jwk {
 }
 
 /// A JWK set
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct JwkSet {
     pub keys: Vec<Jwk>,
 }


### PR DESCRIPTION
This implements Hash for JwkSet, which allows it to be cached in a hashmap.