### PR TITLE
 Update base64 to 0.22 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rust-version = "1.73.0"
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-base64 = "0.21.0"
+base64 = "0.22"
 # For PEM decoding
 pem = { version = "3", optional = true }
 simple_asn1 = { version = "0.6", optional = true }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ jsonwebtoken = "9"
 serde = {version = "1.0", features = ["derive"] }
 ```
 
-The minimum required Rust version (MSRV) is 1.67.
+The minimum required Rust version (MSRV) is specified in the `rust-version` field in this project's [Cargo.toml](Cargo.toml).
 
 ## Algorithms
 This library currently supports the following:


### PR DESCRIPTION
According to https://github.com/marshallpierce/rust-base64/blob/master/RELEASE-NOTES.md this does not affect this project. (Only change is a speedup, a minor change of the `InvalidLength` error, and a fixed `BIN_HEX`)

Also in a separate doc-only commit, address https://github.com/Keats/jsonwebtoken/pull/380#issuecomment-2030469801 to fix #380.