### PR TITLE
Add unknown variant to KeyAlgorithm

### DIFF
--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -188,6 +188,10 @@ pub enum KeyAlgorithm {
     /// RSAES-OAEP-256 using SHA-2
     #[serde(rename = "RSA-OAEP-256")]
     RSA_OAEP_256,
+
+    /// Catch-All for when the key algorithm can not be determined
+    #[serde(other)]
+    UNKNOWN_ALGORITHM
 }
 
 impl FromStr for KeyAlgorithm {
@@ -435,7 +439,7 @@ impl JwkSet {
 
 #[cfg(test)]
 mod tests {
-    use crate::jwk::{AlgorithmParameters, JwkSet, OctetKeyType};
+    use crate::jwk::{AlgorithmParameters, JwkSet, KeyAlgorithm, OctetKeyType};
     use crate::serialization::b64_encode;
     use crate::Algorithm;
     use serde_json::json;
@@ -470,5 +474,12 @@ mod tests {
             }
             _ => panic!("Unexpected key algorithm"),
         }
+    }
+
+    #[test]
+    fn deserialize_unknown_key_algorithm(){
+        let key_alg_json = json!("");
+        let key_alg_result: KeyAlgorithm = serde_json::from_value(key_alg_json).expect("Could not deserialize json");
+        assert_eq!(key_alg_result,KeyAlgorithm::UNKNOWN_ALGORITHM);
     }
 }


### PR DESCRIPTION
Adding an unknown variant to `KeyAlgorithm` to fix deserialization for future key algorithm variants.


In my use case I have an Identity provider that is giving us a key in the JwkSet of type `ES512`. If even a single JWK in the JWKSet uses an algorithm that is not in the KeyAlgorithm enum it breaks deserialization of the entire JWKSet. I figure that by providing a catch-all variant in the `KeyAlgorithm` enum it should be flexible enough to allow this library to properly deserialize JWKSets even if some of the variants use algorithms that the library doesn't yet support.