### PR TITLE
support ring and aws-lc-rs (default = ring)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ base64 = "0.22"
 # For PEM decoding
 pem = { version = "3", optional = true }
 simple_asn1 = { version = "0.6", optional = true }
+aws-lc-rs = { version = "1.8.1", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ring = { version = "0.17.4", features = ["std"] }
@@ -50,6 +51,7 @@ criterion = { version = "0.4", default-features = false }
 [features]
 default = ["use_pem"]
 use_pem = ["pem", "simple_asn1"]
+aws_lc_rs = ["dep:aws-lc-rs"]
 
 [[bench]]
 name = "jwt"

--- a/src/crypto/core.rs
+++ b/src/crypto/core.rs
@@ -1,0 +1,47 @@
+#[cfg(all(feature = "aws_lc_rs", not(any(target_arch = "wasm32", target_os = "windows"))))]
+pub(crate) mod dep {
+    pub(crate) use ::aws_lc_rs::{constant_time, error, hmac, rand};
+
+    pub(crate) mod signature {
+        pub(crate) use ::aws_lc_rs::signature::*;
+
+        #[inline]
+        pub(crate) fn ecdsa_key_pair_from_pkcs8(
+            alg: &'static EcdsaSigningAlgorithm,
+            pkcs8: &[u8],
+            _rng: &dyn ::aws_lc_rs::rand::SecureRandom,
+        ) -> Result<EcdsaKeyPair, ::aws_lc_rs::error::KeyRejected> {
+            EcdsaKeyPair::from_pkcs8(alg, pkcs8)
+        }
+
+        #[inline]
+        pub(crate) fn rsa_key_pair_public_modulus_len(key_pair: &RsaKeyPair) -> usize {
+            key_pair.public_modulus_len()
+        }
+    }
+}
+
+#[cfg(not(all(feature = "aws_lc_rs", not(any(target_arch = "wasm32", target_os = "windows")))))]
+pub(crate) mod dep {
+    pub(crate) use ::ring::{constant_time, error, hmac, rand};
+
+    pub(crate) mod signature {
+        pub(crate) use ::ring::signature::*;
+
+        #[inline]
+        pub(crate) fn ecdsa_key_pair_from_pkcs8(
+            alg: &'static EcdsaSigningAlgorithm,
+            pkcs8: &[u8],
+            rng: &dyn ::ring::rand::SecureRandom,
+        ) -> Result<EcdsaKeyPair, ::ring::error::KeyRejected> {
+            EcdsaKeyPair::from_pkcs8(alg, pkcs8, rng)
+        }
+
+        #[inline]
+        pub(crate) fn rsa_key_pair_public_modulus_len(key_pair: &RsaKeyPair) -> usize {
+            key_pair.public().modulus_len()
+        }
+    }
+}
+
+pub(crate) use dep::*;

--- a/src/crypto/ecdsa.rs
+++ b/src/crypto/ecdsa.rs
@@ -1,6 +1,5 @@
-use ring::{rand, signature};
-
 use crate::algorithms::Algorithm;
+use crate::crypto::core::{rand, signature};
 use crate::errors::Result;
 use crate::serialization::b64_encode;
 
@@ -32,7 +31,7 @@ pub fn sign(
     message: &[u8],
 ) -> Result<String> {
     let rng = rand::SystemRandom::new();
-    let signing_key = signature::EcdsaKeyPair::from_pkcs8(alg, key, &rng)?;
+    let signing_key = signature::ecdsa_key_pair_from_pkcs8(alg, key, &rng)?;
     let out = signing_key.sign(&rng, message)?;
     Ok(b64_encode(out))
 }

--- a/src/crypto/eddsa.rs
+++ b/src/crypto/eddsa.rs
@@ -1,6 +1,5 @@
-use ring::signature;
-
 use crate::algorithms::Algorithm;
+use crate::crypto::core::signature;
 use crate::errors::Result;
 use crate::serialization::b64_encode;
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,12 +1,12 @@
-use ring::constant_time::verify_slices_are_equal;
-use ring::{hmac, signature};
-
 use crate::algorithms::Algorithm;
+use crate::crypto::core::constant_time::verify_slices_are_equal;
+use crate::crypto::core::{hmac, signature};
 use crate::decoding::{DecodingKey, DecodingKeyKind};
 use crate::encoding::EncodingKey;
 use crate::errors::Result;
 use crate::serialization::{b64_decode, b64_encode};
 
+pub(crate) mod core;
 pub(crate) mod ecdsa;
 pub(crate) mod eddsa;
 pub(crate) mod rsa;

--- a/src/crypto/rsa.rs
+++ b/src/crypto/rsa.rs
@@ -1,6 +1,5 @@
-use ring::{rand, signature};
-
 use crate::algorithms::Algorithm;
+use crate::crypto::core::{rand, signature};
 use crate::errors::{ErrorKind, Result};
 use crate::serialization::{b64_decode, b64_encode};
 
@@ -41,7 +40,7 @@ pub(crate) fn sign(
     let key_pair = signature::RsaKeyPair::from_der(key)
         .map_err(|e| ErrorKind::InvalidRsaKey(e.to_string()))?;
 
-    let mut signature = vec![0; key_pair.public().modulus_len()];
+    let mut signature = vec![0; signature::rsa_key_pair_public_modulus_len(&key_pair)];
     let rng = rand::SystemRandom::new();
     key_pair.sign(alg, &rng, message, &mut signature).map_err(|_| ErrorKind::RsaFailedSigning)?;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -77,7 +77,7 @@ pub enum ErrorKind {
     /// Some of the text was invalid UTF-8
     Utf8(::std::string::FromUtf8Error),
     /// Something unspecified went wrong with crypto
-    Crypto(::ring::error::Unspecified),
+    Crypto(crate::crypto::core::error::Unspecified),
 }
 
 impl StdError for Error {
@@ -159,14 +159,14 @@ impl From<::std::string::FromUtf8Error> for Error {
     }
 }
 
-impl From<::ring::error::Unspecified> for Error {
-    fn from(err: ::ring::error::Unspecified) -> Error {
+impl From<crate::crypto::core::error::Unspecified> for Error {
+    fn from(err: crate::crypto::core::error::Unspecified) -> Error {
         new_error(ErrorKind::Crypto(err))
     }
 }
 
-impl From<::ring::error::KeyRejected> for Error {
-    fn from(_err: ::ring::error::KeyRejected) -> Error {
+impl From<crate::crypto::core::error::KeyRejected> for Error {
+    fn from(_err: crate::crypto::core::error::KeyRejected) -> Error {
         new_error(ErrorKind::InvalidEcdsaKey)
     }
 }


### PR DESCRIPTION
Closes #389 

Tested using:

```
cargo hack check --each-feature --no-dev-deps
cargo test
cargo test --features aws_lc_rs
cargo test --examples
cargo test --examples --features aws_lc_rs
```

Not ran it with wasm / windows enabled though.
But I would hope the flags manage that?

Current approach does mean you always pull in ring, but it shouldn't compile if you are not using it.
Do not know of an elegant way to do it differently. We can make ring a feature as well that is enabled by default,
but it would make it akward for when you have both ring and aws-lc-rs enabled.

rustls fixes that by then just making a runtime error. Bit odd, I would prefer just it to fail then. So that's an option to still add that here, not sure if it's desired/required.