### PR TITLE
Handle verification when multiple algorithms are allowed in the settings

### DIFF
--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -213,10 +213,10 @@ fn verify_signature<'a>(
         return Err(new_error(ErrorKind::MissingAlgorithm));
     }
 
-    if validation.validate_signature {
-        if !validation.algorithms.iter().any(|alg| alg.family() == key.family) {
-            return Err(new_error(ErrorKind::InvalidAlgorithm));
-        }
+    if validation.validate_signature
+        && !validation.algorithms.iter().any(|alg| alg.family() == key.family)
+    {
+        return Err(new_error(ErrorKind::InvalidAlgorithm));
     }
 
     let (signature, message) = expect_two!(token.rsplitn(2, '.'));

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -214,10 +214,8 @@ fn verify_signature<'a>(
     }
 
     if validation.validate_signature {
-        for alg in &validation.algorithms {
-            if key.family != alg.family() {
-                return Err(new_error(ErrorKind::InvalidAlgorithm));
-            }
+        if !validation.algorithms.iter().any(|alg| alg.family() == key.family) {
+            return Err(new_error(ErrorKind::InvalidAlgorithm));
         }
     }
 
@@ -226,6 +224,10 @@ fn verify_signature<'a>(
     let header = Header::from_encoded(header)?;
 
     if validation.validate_signature && !validation.algorithms.contains(&header.alg) {
+        return Err(new_error(ErrorKind::InvalidAlgorithm));
+    }
+
+    if header.alg.family() != key.family {
         return Err(new_error(ErrorKind::InvalidAlgorithm));
     }
 


### PR DESCRIPTION
Previously it was possible to allow multiple algorithms in the validation settings, but if multiple families were allowed, verifying would always fail (because it wanted the decoding key to match all of the families). This change supports settings multiple algorithms/families. This will return an error if:
 1. The decoding key doesn't match the family of any of the allowed algorithms,
 2. The algorithm in the token header is not one of the allowed algorithms, or
 3. The algorithm in the token header is not the same family as the decoding key

I added some tests for these cases. I also added `decode_token_with_multiple_algorithms_allowed`, which would have previously failed.