### PR TITLE
fix: no panic if key_algorithm is not set in JWK

### DIFF
--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -414,7 +414,10 @@ pub struct Jwk {
 impl Jwk {
     /// Find whether the Algorithm is implemented and supported
     pub fn is_supported(&self) -> bool {
-        self.common.key_algorithm.unwrap().to_algorithm().is_ok()
+        match self.common.key_algorithm {
+            Some(alg) => alg.to_algorithm().is_ok(),
+            _ => false,
+        }
     }
 }
 


### PR DESCRIPTION
It is note set here:
https://login.windows.net/common/discovery/keys