### PR TITLE
Support multiple algorithms when decoding

### DIFF
--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -214,10 +214,8 @@ fn verify_signature<'a>(
     }
 
     if validation.validate_signature {
-        for alg in &validation.algorithms {
-            if key.family != alg.family() {
-                return Err(new_error(ErrorKind::InvalidAlgorithm));
-            }
+        if !validation.algorithms.iter().any(|alg| key.family == alg.family()) {
+            return Err(new_error(ErrorKind::InvalidAlgorithm));
         }
     }
 

--- a/tests/hmac.rs
+++ b/tests/hmac.rs
@@ -198,6 +198,26 @@ fn decode_token_wrong_algorithm() {
 
 #[test]
 #[wasm_bindgen_test]
+fn decode_token_multiple_algorithms() {
+    let my_claims = Claims {
+        sub: "b@b.com".to_string(),
+        company: "ACME".to_string(),
+        exp: OffsetDateTime::now_utc().unix_timestamp() + 10000,
+    };
+    let token = encode(&Header::default(), &my_claims, &EncodingKey::from_secret(b"secret")).unwrap();
+
+    let mut validation = Validation::new(Algorithm::RS512);
+    validation.algorithms.push(Algorithm::HS256);
+
+    decode::<Claims>(
+        &token,
+        &DecodingKey::from_secret(b"secret"),
+        &validation,
+    ).unwrap();
+}
+
+#[test]
+#[wasm_bindgen_test]
 #[should_panic(expected = "InvalidAlgorithm")]
 fn encode_wrong_alg_family() {
     let my_claims = Claims {


### PR DESCRIPTION
This pull request introduces improvements to the signature verification logic and adds a new test to ensure proper handling of multiple algorithms during token decoding.

To be clear: If the purpose is to ensure that a single validator always has to have the same family of algorithms, then this PR is invalid. :)

### Improvements to signature verification logic:
* [`src/decoding.rs`](diffhunk://#diff-ed9cfebe1778c57d0df0be4197d90a5b37f13d6cd54363343cfe8743c4e54affL217-L222): Simplified the `validate_signature` block by replacing the loop with a more concise `any` iterator to check if the key's family matches any of the allowed algorithms. This resolves a bug where the validation would fail if the family of the first entry in the supported algorithms array mismatches with the key, even if another algorithm would match.

### Expanded test coverage:
* [`tests/hmac.rs`](diffhunk://#diff-0a2248492cd261be241bddf51ce68745cb49e989d7b02a1c52a342a3f557fa1cR199-R218): Added a new test, `decode_token_multiple_algorithms`, to verify that decoding works correctly when multiple algorithms are specified in the validation object. This ensures compatibility with tokens signed using different algorithms.