### PR TITLE
feat: add `dangerous::insecure_decode`

### DIFF
--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -292,6 +292,23 @@ pub fn decode<T: DeserializeOwned + Clone>(
     Ok(TokenData { header, claims })
 }
 
+/// Decode a JWT with NO VALIDATION
+///
+/// DANGER: This performs zero validation on the JWT
+pub fn insecure_decode<T: DeserializeOwned + Clone>(
+    token: impl AsRef<[u8]>,
+) -> Result<TokenData<T>> {
+    let token = token.as_ref();
+
+    let (_, message) = expect_two!(token.rsplitn(2, |b| *b == b'.'));
+    let (payload, header) = expect_two!(message.rsplitn(2, |b| *b == b'.'));
+
+    let header = Header::from_encoded(header)?;
+    let claims = DecodedJwtPartClaims::from_jwt_part_claims(payload)?.deserialize()?;
+
+    Ok(TokenData { header, claims })
+}
+
 /// Return the correct [`JwtVerifier`] based on the `algorithm`.
 pub fn jwt_verifier_factory(
     algorithm: &Algorithm,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,11 @@ pub use encoding::{EncodingKey, encode};
 pub use header::Header;
 pub use validation::{Validation, get_current_timestamp};
 
+/// Dangerous decoding functions that should be audited and used with extreme care.
+pub mod dangerous {
+    pub use super::decoding::insecure_decode;
+}
+
 mod algorithms;
 /// Lower level functions, if you want to do something other than JWTs
 pub mod crypto;

--- a/tests/dangerous.rs
+++ b/tests/dangerous.rs
@@ -1,0 +1,60 @@
+use jsonwebtoken::{Algorithm, TokenData, dangerous::insecure_decode};
+use wasm_bindgen_test::wasm_bindgen_test;
+
+#[derive(Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Claims {
+    sub: String,
+    aud: Vec<String>,
+    iat: i64,
+    exp: i64,
+}
+
+#[test]
+#[wasm_bindgen_test]
+fn dangerous_insecure_decode_valid_jwt() {
+    let token = "eyJhbGciOiJSUzI1NiIsImtpZCI6IkRReWk2eEFmVVRPWmhJV2R5VWtKZTBFMUJmM1VXV05QIiwidHlwIjoiSldUIn0.eyJhdWQiOlsianNvbndlYnRva2VudGVzdCJdLCJleHAiOjE3NTk4MjYyMTcsImlhdCI6MTc1OTgyNTkxNywic3ViIjoic3BpZmZlOi8vZXhhbXBsZS5vcmcvdGVzdHNlcnZpY2UifQ.1qr1zmMM1hmF-sDZupGc7sT2zGQxl1hFfaUKFWz3UGUeJfUweZfFymGR4jIOJb9ywXmfaafGQbNypaHILPWpeXT8RB7GZ7APu09ZPFvLiKBqagCVWgwhXc30giYPfTq5iNct1ejdYgB1wLxtnrsDRoD_k3EMkB58pDz4H5ZFXc_3xB9TLGw2UdaZ7AloV1yFV6OC5PdleSKchb9E_WaBlbZWLjQNSLhN-YhCRLJ4K59lmL_Z2rnR2812kan8xicyxJAzZ6k0y6K8tpKxUhT--THz2ikUk_olOwDIMfjYe9xmAk-PVvIGwHUVR6fMYv74vhdpwVJACkI2U7HVUhRFkg";
+
+    let TokenData { header, claims } = insecure_decode::<Claims>(token).unwrap();
+
+    assert_eq!(Algorithm::RS256, header.alg);
+    assert_eq!("DQyi6xAfUTOZhIWdyUkJe0E1Bf3UWWNP".to_string(), header.kid.unwrap());
+    assert_eq!(Some("JWT".to_string()), header.typ);
+
+    assert_eq!(vec!["jsonwebtokentest"], claims.aud);
+    assert_eq!("spiffe://example.org/testservice", claims.sub);
+    assert_eq!(1759825917, claims.iat);
+    assert_eq!(1759826217, claims.exp);
+}
+
+#[test]
+#[wasm_bindgen_test]
+fn dangerous_insecure_decode_invalid_sig() {
+    let token = "eyJhbGciOiJSUzI1NiIsImtpZCI6IkRReWk2eEFmVVRPWmhJV2R5VWtKZTBFMUJmM1VXV05QIiwidHlwIjoiSldUIn0.eyJhdWQiOlsianNvbndlYnRva2VudGVzdCJdLCJleHAiOjE3NTk4MjYyMTcsImlhdCI6MTc1OTgyNTkxNywic3ViIjoic3BpZmZlOi8vZXhhbXBsZS5vcmcvdGVzdHNlcnZpY2UifQ.sig";
+
+    let TokenData { header, claims } = insecure_decode::<Claims>(token).unwrap();
+
+    assert_eq!(Algorithm::RS256, header.alg);
+    assert_eq!("DQyi6xAfUTOZhIWdyUkJe0E1Bf3UWWNP".to_string(), header.kid.unwrap());
+    assert_eq!(Some("JWT".to_string()), header.typ);
+
+    assert_eq!(vec!["jsonwebtokentest"], claims.aud);
+    assert_eq!("spiffe://example.org/testservice", claims.sub);
+    assert_eq!(1759825917, claims.iat);
+    assert_eq!(1759826217, claims.exp);
+}
+
+#[test]
+#[wasm_bindgen_test]
+fn dangerous_insecure_decode_invalid_header() {
+    let token = "badz.eyJhdWQiOlsianNvbndlYnRva2VudGVzdCJdLCJleHAiOjE3NTk4MjYyMTcsImlhdCI6MTc1OTgyNTkxNywic3ViIjoic3BpZmZlOi8vZXhhbXBsZS5vcmcvdGVzdHNlcnZpY2UifQ.sig";
+
+    insecure_decode::<Claims>(token).unwrap_err();
+}
+
+#[test]
+#[wasm_bindgen_test]
+fn dangerous_insecure_decode_invalid_claims() {
+    let token = "eyJhbGciOiJSUzI1NiIsImtpZCI6IkRReWk2eEFmVVRPWmhJV2R5VWtKZTBFMUJmM1VXV05QIiwidHlwIjoiSldUIn0.badz.sig";
+
+    insecure_decode::<Claims>(token).unwrap_err();
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,3 +1,4 @@
+mod dangerous;
 mod ecdsa;
 mod eddsa;
 mod header;


### PR DESCRIPTION
Add `jsonwebtoken::dangerous::insecure_decode` to support decoding headers and claims with no signature validation.

This should fulfill #401 and also provides a solution for #438