### PR TITLE
fix(docs): add `rust_crypto` feature to docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ include = [
 ]
 rust-version = "1.85.0"
 
+[package.metadata.docs.rs]
+features = ["rust_crypto"]
+
 [dependencies]
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Add `rust_crypto` feature to docs.rs build to resolve failing docs.rs build.

Closes #440