### PR TITLE
Custom header support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ rand = { version = "0.8.5", optional = true, features = ["std"], default-feature
 rsa = { version = "0.9.6", optional = true }
 sha2 = { version = "0.10.7", optional = true, features = ["oid"] }
 
+# proc-macros (e.g. Header, claims)
+jsonwebtoken-proc-macros = { path = "jsonwebtoken-proc-macros" }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"
 getrandom = "0.2"

--- a/jsonwebtoken-proc-macros/Cargo.toml
+++ b/jsonwebtoken-proc-macros/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "jsonwebtoken-proc-macros"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0.41"
+syn = { version = "2.0.106", features = ["full"] }

--- a/jsonwebtoken-proc-macros/src/lib.rs
+++ b/jsonwebtoken-proc-macros/src/lib.rs
@@ -1,0 +1,100 @@
+//! This library provides convenient derive and attribute macros for custom Header and Claim
+//! structs for `jsonwebtoken`.
+//!
+//! Example
+//! ```rust
+//! use jsonwebtoken::Algorithm;
+//! use jsonwebtoken::macros::header;
+//! #[header]
+//! struct CustomJwtHeader {
+//!     // `alg` is the only required struct field
+//!     alg: Algorithm,
+//!     custom_header: Option<String>,
+//!     another_custom_header: String,
+//! }
+//! ````
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, Item, ItemStruct, parse_macro_input};
+
+/// Convenience macro for JWT header structs
+///
+/// Adds the following derive macros:
+/// ```rust
+/// #[derive(
+///     Debug,
+///     Clone,
+///     Default,
+///     serde::Serialize,
+///     serde::Deserialize
+/// )]
+/// ```
+#[proc_macro_attribute]
+pub fn claims(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    let mut item = parse_macro_input!(input as Item);
+
+    match &mut item {
+        Item::Struct(ItemStruct { attrs, .. }) => {
+            attrs.push(
+                syn::parse_quote!(#[derive(Debug, Clone, Default, jsonwebtoken::serde::Serialize, jsonwebtoken::serde::Deserialize)]),
+            );
+            quote!(#item).into()
+        }
+        _ => syn::Error::new_spanned(&item, "#[header] can only be used on structs")
+            .to_compile_error()
+            .into(),
+    }
+}
+
+/// Convenience macro for JWT header structs
+///
+/// Adds the following derive macros:
+/// ```rust
+/// #[derive(
+///     Debug,
+///     Clone,
+///     Default,
+///     jsonwebtoken::macros::Header,
+///     serde::Serialize,
+///     serde::Deserialize
+/// )]
+/// ```
+#[proc_macro_attribute]
+pub fn header(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    let mut item = parse_macro_input!(input as Item);
+
+    match &mut item {
+        Item::Struct(ItemStruct { attrs, .. }) => {
+            attrs.push(syn::parse_quote!(#[derive(Debug, Clone, Default, jsonwebtoken::serde::Serialize, jsonwebtoken::serde::Deserialize, jsonwebtoken::macros::Header)]));
+            quote!(#item).into()
+        }
+        _ => syn::Error::new_spanned(&item, "#[header] can only be used on structs")
+            .to_compile_error()
+            .into(),
+    }
+}
+
+/// Derive macro required for custom JWT headers used with `jsonwebtoken`
+///
+/// Requires an `alg: jsonwebtoken::Algorithm` field exists in the struct
+#[proc_macro_derive(Header)]
+pub fn derive_header(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let name = &input.ident;
+    let generics = &input.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let expanded = quote! {
+        impl #impl_generics ::jsonwebtoken::header::FromEncoded for #name #ty_generics #where_clause {}
+        impl #impl_generics ::jsonwebtoken::header::Alg for #name #ty_generics #where_clause {
+            fn alg(&self) -> &::jsonwebtoken::Algorithm {
+                &self.alg
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -325,7 +325,7 @@ where
 /// DANGER: This performs zero validation on the JWT
 pub fn insecure_decode<T: DeserializeOwned + Clone>(
     token: impl AsRef<[u8]>,
-) -> Result<TokenData<T>> {
+) -> Result<TokenData<Header, T>> {
     let token = token.as_ref();
 
     let (_, message) = expect_two!(token.rsplitn(2, |b| *b == b'.'));

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -153,10 +153,9 @@ impl Debug for EncodingKey {
 /// If the algorithm given is RSA or EC, the key needs to be in the PEM format.
 ///
 /// ```rust
-/// use serde::{Deserialize, Serialize};
-/// use jsonwebtoken::{encode, Algorithm, Header, EncodingKey};
+/// use jsonwebtoken::{encode, macros::claims, Algorithm, Header, EncodingKey};
 ///
-/// #[derive(Debug, Serialize, Deserialize)]
+/// #[claims]
 /// struct Claims {
 ///    sub: String,
 ///    company: String

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -10,7 +10,7 @@ use crate::Algorithm;
 use crate::algorithms::AlgorithmFamily;
 use crate::crypto::JwtSigner;
 use crate::errors::{ErrorKind, Result, new_error};
-use crate::header::Header;
+use crate::header::Alg;
 #[cfg(feature = "use_pem")]
 use crate::pem::decoder::PemEncodedKey;
 use crate::serialization::{b64_encode, b64_encode_part};
@@ -171,14 +171,18 @@ impl Debug for EncodingKey {
 /// // This will create a JWT using HS256 as algorithm
 /// let token = encode(&Header::default(), &my_claims, &EncodingKey::from_secret("secret".as_ref())).unwrap();
 /// ```
-pub fn encode<T: Serialize>(header: &Header, claims: &T, key: &EncodingKey) -> Result<String> {
-    if key.family != header.alg.family() {
+pub fn encode<H: Serialize + Alg, T: Serialize>(
+    header: &H,
+    claims: &T,
+    key: &EncodingKey,
+) -> Result<String> {
+    if key.family != header.alg().family() {
         return Err(new_error(ErrorKind::InvalidAlgorithm));
     }
 
-    let signing_provider = jwt_signer_factory(&header.alg, key)?;
+    let signing_provider = jwt_signer_factory(header.alg(), key)?;
 
-    if signing_provider.algorithm() != header.alg {
+    if signing_provider.algorithm() != *header.alg() {
         return Err(new_error(ErrorKind::InvalidAlgorithm));
     }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -3,11 +3,13 @@ use std::collections::HashMap;
 use std::result;
 
 use base64::{Engine, engine::general_purpose::STANDARD};
+use jsonwebtoken_proc_macros::header;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::algorithms::Algorithm;
 use crate::errors::Result;
 use crate::jwk::Jwk;
+use crate::macros::Header;
 use crate::serialization::b64_decode;
 
 const ZIP_SERIAL_DEFLATE: &str = "DEF";
@@ -137,7 +139,7 @@ pub trait FromEncoded {
 
 /// A basic JWT header, the alg defaults to HS256 and typ is automatically
 /// set to `JWT`. All the other fields are optional.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Header, Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Header {
     /// The type of JWS: it can only be "JWT" here
     ///
@@ -254,24 +256,10 @@ impl Header {
     }
 }
 
-impl Default for Header {
-    /// Returns a JWT header using the default Algorithm, HS256
-    fn default() -> Self {
-        Header::new(Algorithm::default())
-    }
-}
-
-impl Alg for Header {
-    fn alg(&self) -> &Algorithm {
-        &self.alg
-    }
-}
-
-impl FromEncoded for Header {}
-
 /// A truly basic JWT header, the alg defaults to HS256 and typ is automatically
 /// set to `JWT`. All the other fields are optional.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[header]
+#[derive(Hash, PartialEq, Eq)]
 pub struct BasicHeader {
     /// The type of JWS: it can only be "JWT" here
     ///
@@ -370,18 +358,3 @@ impl BasicHeader {
         }
     }
 }
-
-impl Default for BasicHeader {
-    /// Returns a JWT header using the default Algorithm, HS256
-    fn default() -> Self {
-        Self::new(Algorithm::default())
-    }
-}
-
-impl Alg for BasicHeader {
-    fn alg(&self) -> &Algorithm {
-        &self.alg
-    }
-}
-
-impl FromEncoded for BasicHeader {}

--- a/src/header.rs
+++ b/src/header.rs
@@ -268,3 +268,120 @@ impl Alg for Header {
 }
 
 impl FromEncoded for Header {}
+
+/// A truly basic JWT header, the alg defaults to HS256 and typ is automatically
+/// set to `JWT`. All the other fields are optional.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BasicHeader {
+    /// The type of JWS: it can only be "JWT" here
+    ///
+    /// Defined in [RFC7515#4.1.9](https://tools.ietf.org/html/rfc7515#section-4.1.9).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub typ: Option<String>,
+    /// The algorithm used
+    ///
+    /// Defined in [RFC7515#4.1.1](https://tools.ietf.org/html/rfc7515#section-4.1.1).
+    pub alg: Algorithm,
+    /// Content type
+    ///
+    /// Defined in [RFC7519#5.2](https://tools.ietf.org/html/rfc7519#section-5.2).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cty: Option<String>,
+    /// JSON Key URL
+    ///
+    /// Defined in [RFC7515#4.1.2](https://tools.ietf.org/html/rfc7515#section-4.1.2).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jku: Option<String>,
+    /// JSON Web Key
+    ///
+    /// Defined in [RFC7515#4.1.3](https://tools.ietf.org/html/rfc7515#section-4.1.3).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jwk: Option<Jwk>,
+    /// Key ID
+    ///
+    /// Defined in [RFC7515#4.1.4](https://tools.ietf.org/html/rfc7515#section-4.1.4).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kid: Option<String>,
+    /// X.509 URL
+    ///
+    /// Defined in [RFC7515#4.1.5](https://tools.ietf.org/html/rfc7515#section-4.1.5).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub x5u: Option<String>,
+    /// X.509 certificate chain. A Vec of base64 encoded ASN.1 DER certificates.
+    ///
+    /// Defined in [RFC7515#4.1.6](https://tools.ietf.org/html/rfc7515#section-4.1.6).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub x5c: Option<Vec<String>>,
+    /// X.509 SHA1 certificate thumbprint
+    ///
+    /// Defined in [RFC7515#4.1.7](https://tools.ietf.org/html/rfc7515#section-4.1.7).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub x5t: Option<String>,
+    /// X.509 SHA256 certificate thumbprint
+    ///
+    /// Defined in [RFC7515#4.1.8](https://tools.ietf.org/html/rfc7515#section-4.1.8).
+    ///
+    /// This will be serialized/deserialized as "x5t#S256", as defined by the RFC.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "x5t#S256")]
+    pub x5t_s256: Option<String>,
+    /// Critical - indicates header fields that must be understood by the receiver.
+    ///
+    /// Defined in [RFC7515#4.1.6](https://tools.ietf.org/html/rfc7515#section-4.1.6).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub crit: Option<Vec<String>>,
+    /// See `Enc` for description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enc: Option<Enc>,
+    /// See `Zip` for description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zip: Option<Zip>,
+    /// ACME: The URL to which this JWS object is directed
+    ///
+    /// Defined in [RFC8555#6.4](https://datatracker.ietf.org/doc/html/rfc8555#section-6.4).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// ACME: Random data for preventing replay attacks.
+    ///
+    /// Defined in [RFC8555#6.5.2](https://datatracker.ietf.org/doc/html/rfc8555#section-6.5.2).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<String>,
+}
+
+impl BasicHeader {
+    /// Returns a JWT header with the algorithm given
+    pub fn new(algorithm: Algorithm) -> Self {
+        Self {
+            typ: Some("JWT".to_string()),
+            alg: algorithm,
+            cty: None,
+            jku: None,
+            jwk: None,
+            kid: None,
+            x5u: None,
+            x5c: None,
+            x5t: None,
+            x5t_s256: None,
+            crit: None,
+            enc: None,
+            zip: None,
+            url: None,
+            nonce: None,
+        }
+    }
+}
+
+impl Default for BasicHeader {
+    /// Returns a JWT header using the default Algorithm, HS256
+    fn default() -> Self {
+        Self::new(Algorithm::default())
+    }
+}
+
+impl Alg for BasicHeader {
+    fn alg(&self) -> &Algorithm {
+        &self.alg
+    }
+}
+
+impl FromEncoded for BasicHeader {}

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -596,7 +596,7 @@ impl Jwk {
 
     /// Compute the thumbprint of the JWK.
     ///
-    /// Per [RFC-7638](https://datatracker.ietf.org/doc/html/rfc7638)
+    /// Per (RFC-7638)[<https://datatracker.ietf.org/doc/html/rfc7638>]
     pub fn thumbprint(&self, hash_function: ThumbprintHash) -> String {
         let pre = match &self.algorithm {
             AlgorithmParameters::EllipticCurve(a) => match a.curve {

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -5,7 +5,10 @@ use crate::crypto::sign;
 use crate::errors::{ErrorKind, Result, new_error};
 use crate::serialization::{DecodedJwtPartClaims, b64_encode_part};
 use crate::validation::validate;
-use crate::{DecodingKey, EncodingKey, Header, TokenData, Validation};
+use crate::{
+    DecodingKey, EncodingKey, TokenData, Validation,
+    header::{FromEncoded, Header},
+};
 
 use crate::decoding::{jwt_verifier_factory, verify_signature_body};
 use serde::de::DeserializeOwned;
@@ -63,7 +66,7 @@ pub fn decode<T: DeserializeOwned>(
     jws: &Jws<T>,
     key: &DecodingKey,
     validation: &Validation,
-) -> Result<TokenData<T>> {
+) -> Result<TokenData<Header, T>> {
     let header = Header::from_encoded(&jws.protected)?;
     let message = [jws.protected.as_str(), jws.payload.as_str()].join(".");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,9 @@ compile_error!(
 compile_error!("at least one of the features \"rust_crypto\" or \"aws_lc_rs\" must be enabled");
 
 pub use algorithms::Algorithm;
-pub use decoding::{DecodingKey, TokenData, decode, decode_header};
+pub use decoding::{
+    DecodingKey, TokenData, decode, decode_custom_header, decode_header, decode_with_custom_header,
+};
 pub use encoding::{EncodingKey, encode};
 pub use header::Header;
 pub use validation::{Validation, get_current_timestamp};
@@ -31,7 +33,7 @@ mod decoding;
 mod encoding;
 /// All the errors that can be encountered while encoding/decoding JWTs
 pub mod errors;
-mod header;
+pub mod header;
 pub mod jwk;
 pub mod jws;
 #[cfg(feature = "use_pem")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,14 @@ compile_error!(
 #[cfg(not(any(feature = "rust_crypto", feature = "aws_lc_rs")))]
 compile_error!("at least one of the features \"rust_crypto\" or \"aws_lc_rs\" must be enabled");
 
+// hidden export of `self` as `jsonwebtoken` required by proc macros
+#[doc(hidden)]
+extern crate self as jsonwebtoken;
+
+// hidden re-export of serde for proc macros
+#[doc(hidden)]
+pub use serde;
+
 pub use algorithms::Algorithm;
 pub use decoding::{
     DecodingKey, TokenData, decode, decode_custom_header, decode_header, decode_with_custom_header,
@@ -33,10 +41,17 @@ mod decoding;
 mod encoding;
 /// All the errors that can be encountered while encoding/decoding JWTs
 pub mod errors;
-pub mod header;
 pub mod jwk;
 pub mod jws;
 #[cfg(feature = "use_pem")]
 mod pem;
 mod serialization;
 mod validation;
+
+#[doc(hidden)]
+pub mod header;
+
+/// Derive macros for custom JWT Header and Claims
+pub mod macros {
+    pub use jsonwebtoken_proc_macros::{Header, claims, header};
+}


### PR DESCRIPTION
In service of #439 

Adds support for custom headers via `decode_with_custom_header` to decode and validate JWT, and a standalone header-only decode via `decode_custom_header`. Those should probably have better names before this is merged. The existing `decode` and `decode_header` functions retain full backwards compatibility.

Also adds convenience macros for claims and custom headers, `jsonwebtoken::macros::claims` and `jsonwebtoken::macros::header`, and a `Header` derive macro.

Adds a `BasicHeader` to fulfill #439 (i.e. implement `Hash`). I have mixed feelings on that one. I think ideally `extras` wouldn't exist on the original `Header` struct, which was itself a breaking change (#420) due to removing the `Hash` implementation, but removing it now would be a breaking change. Given those constraints, adding a `BasicHeader` is the only path I could think of to resolve #439 and also to avoid the minor performance hit of using a HashMap (along w/ the inherent risk of a malicious user intentionally sending JWTs with abnormally large headers containing a large number fields).