### PR TITLE
Fix a few markdown issues in docs

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,6 +1,11 @@
 //! The cryptography of the `jsonwebtoken` crate is decoupled behind
 //! [`JwtSigner`] and [`JwtVerifier`] traits. These make use of `RustCrypto`'s
 //! [`Signer`] and [`Verifier`] traits respectively.
+//!
+//! [`JwtSigner`]: crate::crypto::JwtSigner
+//! [`JwtVerifier`]: crate::crypto::JwtVerifier
+//! [`Signer`]: signature::Signer
+//! [`Verifier`]: signature::Verifier
 
 use crate::algorithms::Algorithm;
 use crate::errors::Result;

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 //! This crate contains types only for working JWK and JWK Sets
 //! This is only meant to be used to deal with public JWK, not generate ones.
-//! Most of the code in this file is taken from https://github.com/lawliet89/biscuit but
+//! Most of the code in this file is taken from <https://github.com/lawliet89/biscuit> but
 //! tweaked to remove the private bits as it's not the goal for this crate currently.
 
 use std::{fmt, str::FromStr};
@@ -596,7 +596,7 @@ impl Jwk {
 
     /// Compute the thumbprint of the JWK.
     ///
-    /// Per (RFC-7638)[https://datatracker.ietf.org/doc/html/rfc7638]
+    /// Per [RFC-7638](https://datatracker.ietf.org/doc/html/rfc7638)
     pub fn thumbprint(&self, hash_function: ThumbprintHash) -> String {
         let pre = match &self.algorithm {
             AlgorithmParameters::EllipticCurve(a) => match a.curve {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 //! Create and parses JWT (JSON Web Tokens)
 //!
-//! Documentation:  [stable](https://docs.rs/jsonwebtoken/)
+//! Documentation:  [stable](https://docs.rs/jsonwebtoken)
+//!
+
 #![deny(missing_docs)]
 
 #[cfg(all(feature = "rust_crypto", feature = "aws_lc_rs"))]


### PR DESCRIPTION
Just minor touch ups that `cargo doc` was complaining about.