### PR TITLE
feat: getrandom v0.3 and ic_cdk::time instead of js_sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ rsa = { version = "0.9.6", optional = true }
 sha2 = { version = "0.10.7", optional = true, features = ["oid"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3"
-getrandom = "0.2"
+getrandom = "0.3"
+ic-cdk = "0.18.5"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.1"

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -183,7 +183,7 @@ pub fn get_current_timestamp() -> u64 {
 #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
 #[must_use]
 pub fn get_current_timestamp() -> u64 {
-    js_sys::Date::new_0().get_time() as u64 / 1000
+    (ic_cdk::api::time() / 1_000_000_000) as u64
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
**Ignore: Opened by mistake**

For context: in my fork, I’m exploring whether it’s possible to use `jsonwebtoken` on the [Internet Computer](https://internetcomputer.org/).

Sorry for the noise!!!
