### PR TITLE
Use dep: prefix to remove implicit feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,9 @@ criterion = { version = "0.4", default-features = false }
 
 [features]
 default = ["use_pem"]
-use_pem = ["pem", "simple_asn1"]
-rust_crypto = ["ed25519-dalek", "hmac", "p256", "p384", "rand", "rsa", "sha2"]
-aws_lc_rs = ["aws-lc-rs"]
+use_pem = ["dep:pem", "dep:simple_asn1"]
+rust_crypto = ["dep:ed25519-dalek", "dep:hmac", "dep:p256", "dep:p384", "dep:rand", "dep:rsa", "dep:sha2"]
+aws_lc_rs = ["dep:aws-lc-rs"]
 
 [[bench]]
 name = "jwt"


### PR DESCRIPTION
This Pull Request updates the project to use the `dep:` prefix.

By using the `dep:` prefix, it removes the implicit feature flags that are automatically enabled by optional dependencies.
For more details about the `dep:` prefix, see <https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies>.

If these implicit feature flags were intentional, this Pull Request is not appropriate and should be closed.
If they were not, merging this Pull Request will ensure that only explicitly defined feature flags are provided.