### PR TITLE
Feature Discussion: Make rsa optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,10 @@ time = { version = "0.3", features = ["wasm-bindgen"] }
 criterion = { version = "0.4", default-features = false }
 
 [features]
-default = ["use_pem"]
+default = ["use_pem", "rsa"]
 use_pem = ["pem", "simple_asn1"]
-rust_crypto = ["ed25519-dalek", "hmac", "p256", "p384", "rand", "rsa", "sha2"]
-aws_lc_rs = ["aws-lc-rs"]
+rust_crypto = ["ed25519-dalek", "hmac", "p256", "p384", "rand", "sha2"]
+aws_lc_rs = ["aws-lc-rs", "rsa"]
 
 [[bench]]
 name = "jwt"

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -7,6 +7,8 @@ use crate::errors::{Error, ErrorKind, Result};
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize, Deserialize)]
 pub enum AlgorithmFamily {
     Hmac,
+
+    #[cfg(feature = "rsa")]
     Rsa,
     Ec,
     Ed,
@@ -17,6 +19,7 @@ impl AlgorithmFamily {
     pub fn algorithms(&self) -> &[Algorithm] {
         match self {
             Self::Hmac => &[Algorithm::HS256, Algorithm::HS384, Algorithm::HS512],
+            #[cfg(feature = "rsa")]
             Self::Rsa => &[
                 Algorithm::RS256,
                 Algorithm::RS384,
@@ -48,17 +51,23 @@ pub enum Algorithm {
     /// ECDSA using SHA-384
     ES384,
 
+    #[cfg(feature = "rsa")]
     /// RSASSA-PKCS1-v1_5 using SHA-256
     RS256,
+    #[cfg(feature = "rsa")]
     /// RSASSA-PKCS1-v1_5 using SHA-384
     RS384,
+    #[cfg(feature = "rsa")]
     /// RSASSA-PKCS1-v1_5 using SHA-512
     RS512,
 
+    #[cfg(feature = "rsa")]
     /// RSASSA-PSS using SHA-256
     PS256,
+    #[cfg(feature = "rsa")]
     /// RSASSA-PSS using SHA-384
     PS384,
+    #[cfg(feature = "rsa")]
     /// RSASSA-PSS using SHA-512
     PS512,
 
@@ -75,11 +84,17 @@ impl FromStr for Algorithm {
             "HS512" => Ok(Algorithm::HS512),
             "ES256" => Ok(Algorithm::ES256),
             "ES384" => Ok(Algorithm::ES384),
+            #[cfg(feature = "rsa")]
             "RS256" => Ok(Algorithm::RS256),
+            #[cfg(feature = "rsa")]
             "RS384" => Ok(Algorithm::RS384),
+            #[cfg(feature = "rsa")]
             "PS256" => Ok(Algorithm::PS256),
+            #[cfg(feature = "rsa")]
             "PS384" => Ok(Algorithm::PS384),
+            #[cfg(feature = "rsa")]
             "PS512" => Ok(Algorithm::PS512),
+            #[cfg(feature = "rsa")]
             "RS512" => Ok(Algorithm::RS512),
             "EdDSA" => Ok(Algorithm::EdDSA),
             _ => Err(ErrorKind::InvalidAlgorithmName.into()),
@@ -91,6 +106,7 @@ impl Algorithm {
     pub(crate) fn family(self) -> AlgorithmFamily {
         match self {
             Algorithm::HS256 | Algorithm::HS384 | Algorithm::HS512 => AlgorithmFamily::Hmac,
+            #[cfg(feature = "rsa")]
             Algorithm::RS256
             | Algorithm::RS384
             | Algorithm::RS512
@@ -115,12 +131,15 @@ mod tests {
         assert!(Algorithm::from_str("HS256").is_ok());
         assert!(Algorithm::from_str("HS384").is_ok());
         assert!(Algorithm::from_str("HS512").is_ok());
-        assert!(Algorithm::from_str("RS256").is_ok());
-        assert!(Algorithm::from_str("RS384").is_ok());
-        assert!(Algorithm::from_str("RS512").is_ok());
-        assert!(Algorithm::from_str("PS256").is_ok());
-        assert!(Algorithm::from_str("PS384").is_ok());
-        assert!(Algorithm::from_str("PS512").is_ok());
+        #[cfg(feature = "rsa")]
+        {
+            assert!(Algorithm::from_str("RS256").is_ok());
+            assert!(Algorithm::from_str("RS384").is_ok());
+            assert!(Algorithm::from_str("RS512").is_ok());
+            assert!(Algorithm::from_str("PS256").is_ok());
+            assert!(Algorithm::from_str("PS384").is_ok());
+            assert!(Algorithm::from_str("PS512").is_ok());
+        }
         assert!(Algorithm::from_str("").is_err());
     }
 }

--- a/src/crypto/rust_crypto/ecdsa.rs
+++ b/src/crypto/rust_crypto/ecdsa.rs
@@ -8,10 +8,10 @@ use crate::{Algorithm, DecodingKey, EncodingKey};
 use p256::ecdsa::{
     Signature as Signature256, SigningKey as SigningKey256, VerifyingKey as VerifyingKey256,
 };
+use p256::pkcs8::DecodePrivateKey;
 use p384::ecdsa::{
     Signature as Signature384, SigningKey as SigningKey384, VerifyingKey as VerifyingKey384,
 };
-use rsa::pkcs8::DecodePrivateKey;
 use signature::{Error, Signer, Verifier};
 
 macro_rules! define_ecdsa_signer {

--- a/src/crypto/rust_crypto/mod.rs
+++ b/src/crypto/rust_crypto/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod ecdsa;
 pub(crate) mod eddsa;
 pub(crate) mod hmac;
+#[cfg(feature = "rsa")]
 pub(crate) mod rsa;

--- a/src/pem/decoder.rs
+++ b/src/pem/decoder.rs
@@ -168,6 +168,7 @@ impl PemEncodedKey {
         }
     }
 
+    #[cfg(feature = "rsa")]
     /// Can be PKCS1 or PKCS8
     pub fn as_rsa_key(&self) -> Result<&[u8]> {
         match self.standard {

--- a/tests/dangerous.rs
+++ b/tests/dangerous.rs
@@ -9,6 +9,7 @@ pub struct Claims {
     exp: i64,
 }
 
+#[cfg(feature = "rsa")]
 #[test]
 #[wasm_bindgen_test]
 fn dangerous_insecure_decode_valid_jwt() {
@@ -26,6 +27,7 @@ fn dangerous_insecure_decode_valid_jwt() {
     assert_eq!(1759826217, claims.exp);
 }
 
+#[cfg(feature = "rsa")]
 #[test]
 #[wasm_bindgen_test]
 fn dangerous_insecure_decode_invalid_sig() {

--- a/tests/hmac.rs
+++ b/tests/hmac.rs
@@ -19,6 +19,7 @@ pub struct Claims {
     exp: i64,
 }
 
+#[cfg(feature = "rsa")]
 #[test]
 #[wasm_bindgen_test]
 fn sign_hs256() {
@@ -185,6 +186,7 @@ fn decode_token_invalid_signature() {
     assert_eq!(claims.unwrap_err().into_kind(), ErrorKind::InvalidSignature);
 }
 
+#[cfg(feature = "rsa")]
 #[test]
 #[wasm_bindgen_test]
 fn decode_token_wrong_algorithm() {
@@ -197,6 +199,7 @@ fn decode_token_wrong_algorithm() {
     assert_eq!(claims.unwrap_err().into_kind(), ErrorKind::InvalidAlgorithm);
 }
 
+#[cfg(feature = "rsa")]
 #[test]
 #[wasm_bindgen_test]
 fn encode_wrong_alg_family() {
@@ -271,6 +274,7 @@ fn dangerous_insecure_decode_token_with_validation_wrong_algorithm() {
     assert_eq!(err.kind(), &ErrorKind::ExpiredSignature);
 }
 
+#[cfg(feature = "rsa")]
 #[test]
 #[wasm_bindgen_test]
 fn verify_hs256_rfc7517_appendix_a1() {

--- a/tests/rsa/mod.rs
+++ b/tests/rsa/mod.rs
@@ -10,6 +10,7 @@ use jsonwebtoken::{
 #[cfg(feature = "use_pem")]
 use jsonwebtoken::{Header, Validation, decode, encode};
 
+#[cfg(feature = "rsa")]
 const RSA_ALGORITHMS: &[Algorithm] = &[
     Algorithm::RS256,
     Algorithm::RS384,
@@ -26,7 +27,7 @@ pub struct Claims {
     exp: i64,
 }
 
-#[cfg(feature = "use_pem")]
+#[cfg(all(feature = "use_pem", feature = "rsa"))]
 #[test]
 #[wasm_bindgen_test]
 fn round_trip_sign_verification_pem_pkcs1() {
@@ -58,7 +59,7 @@ fn round_trip_sign_verification_pem_pkcs1() {
     }
 }
 
-#[cfg(feature = "use_pem")]
+#[cfg(all(feature = "use_pem", feature = "rsa"))]
 #[test]
 #[wasm_bindgen_test]
 fn round_trip_sign_verification_pem_pkcs8() {
@@ -90,6 +91,7 @@ fn round_trip_sign_verification_pem_pkcs8() {
     }
 }
 
+#[cfg(all(feature = "use_pem", feature = "rsa"))]
 #[test]
 #[wasm_bindgen_test]
 fn round_trip_sign_verification_der() {
@@ -105,7 +107,7 @@ fn round_trip_sign_verification_der() {
     }
 }
 
-#[cfg(feature = "use_pem")]
+#[cfg(all(feature = "use_pem", feature = "rsa"))]
 #[test]
 #[wasm_bindgen_test]
 fn round_trip_claim() {
@@ -142,7 +144,7 @@ fn round_trip_claim() {
     }
 }
 
-#[cfg(feature = "use_pem")]
+#[cfg(all(feature = "use_pem", feature = "rsa"))]
 #[test]
 #[wasm_bindgen_test]
 fn rsa_modulus_exponent() {
@@ -169,7 +171,7 @@ fn rsa_modulus_exponent() {
     assert!(res.is_ok());
 }
 
-#[cfg(feature = "use_pem")]
+#[cfg(all(feature = "use_pem", feature = "rsa"))]
 #[test]
 #[wasm_bindgen_test]
 fn rsa_jwk() {
@@ -206,7 +208,7 @@ fn rsa_jwk() {
 }
 
 // https://jwt.io/ is often used for examples so ensure their example works with jsonwebtoken
-#[cfg(feature = "use_pem")]
+#[cfg(all(feature = "use_pem", feature = "rsa"))]
 #[test]
 #[wasm_bindgen_test]
 fn roundtrip_with_jwtio_example_jey() {
@@ -243,7 +245,7 @@ fn roundtrip_with_jwtio_example_jey() {
     }
 }
 
-#[cfg(feature = "use_pem")]
+#[cfg(all(feature = "use_pem", feature = "rsa"))]
 #[test]
 #[wasm_bindgen_test]
 fn rsa_jwk_from_key() {


### PR DESCRIPTION
# Description

This PR should serve as the basis of a discussion since I am not sure myself if it is a good idea or not. But maybe a few words on how I got here. I am currently using this crate in one of my projects and I really like it so far. However the audit tools complain about [this vulnerability (RUSTSEC-2023-0071)](https://rustsec.org/advisories/RUSTSEC-2023-0071). 
I am not 100% sure if this vulnerability affects the `jsonwebtoken` crate or not and its also not that important since I am using no RSA functionality. 

This brought me to the code  and it looked like all the `rsa` parts can be made optional and it is still a very useful crate. 
To not break everything for everyone it should remain a `default` feature for now so users of this library would not have a breaking change, but people who want to skip `rsa` can do so.

## Questions for Discussion

1. Does this approach make sense for the project?
2. Should we also make RSA optional when using `aws_lc_rs`?
3. Are there any concerns about feature flag complexity?

