### PR TITLE
Make crate work when two crypto backends are selected

### DIFF
--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -24,7 +24,7 @@ use crate::crypto::aws_lc::{
         RsaPss512Verifier,
     },
 };
-#[cfg(feature = "rust_crypto")]
+#[cfg(all(not(feature = "aws_lc_rs"), feature = "rust_crypto"))]
 use crate::crypto::rust_crypto::{
     ecdsa::{Es256Verifier, Es384Verifier},
     eddsa::EdDSAVerifier,

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -24,7 +24,7 @@ use crate::crypto::aws_lc::{
         Rsa256Signer, Rsa384Signer, Rsa512Signer, RsaPss256Signer, RsaPss384Signer, RsaPss512Signer,
     },
 };
-#[cfg(feature = "rust_crypto")]
+#[cfg(all(not(feature = "aws_lc_rs"), feature = "rust_crypto"))]
 use crate::crypto::rust_crypto::{
     ecdsa::{Es256Signer, Es384Signer},
     eddsa::EdDSASigner,

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -18,13 +18,13 @@ use crate::{
 use aws_lc_rs::{digest, signature as aws_sig};
 #[cfg(feature = "aws_lc_rs")]
 use aws_sig::KeyPair;
-#[cfg(feature = "rust_crypto")]
+#[cfg(all(not(feature = "aws_lc_rs"), feature = "rust_crypto"))]
 use p256::{ecdsa::SigningKey as P256SigningKey, pkcs8::DecodePrivateKey};
-#[cfg(feature = "rust_crypto")]
+#[cfg(all(not(feature = "aws_lc_rs"), feature = "rust_crypto"))]
 use p384::ecdsa::SigningKey as P384SigningKey;
-#[cfg(feature = "rust_crypto")]
+#[cfg(all(not(feature = "aws_lc_rs"), feature = "rust_crypto"))]
 use rsa::{RsaPrivateKey, pkcs1::DecodeRsaPrivateKey, traits::PublicKeyParts};
-#[cfg(feature = "rust_crypto")]
+#[cfg(all(not(feature = "aws_lc_rs"), feature = "rust_crypto"))]
 use sha2::{Digest, Sha256, Sha384, Sha512};
 
 /// The intended usage of the public `KeyType`. This enum is serialized `untagged`
@@ -448,7 +448,7 @@ fn extract_rsa_public_key_components(key_content: &[u8]) -> errors::Result<(Vec<
     Ok((components.n, components.e))
 }
 
-#[cfg(feature = "rust_crypto")]
+#[cfg(all(not(feature = "aws_lc_rs"), feature = "rust_crypto"))]
 fn extract_rsa_public_key_components(key_content: &[u8]) -> errors::Result<(Vec<u8>, Vec<u8>)> {
     let private_key = RsaPrivateKey::from_pkcs1_der(key_content)
         .map_err(|e| ErrorKind::InvalidRsaKey(e.to_string()))?;
@@ -483,7 +483,7 @@ fn extract_ec_public_key_coordinates(
     Ok((curve, x.to_vec(), y.to_vec()))
 }
 
-#[cfg(feature = "rust_crypto")]
+#[cfg(all(not(feature = "aws_lc_rs"), feature = "rust_crypto"))]
 fn extract_ec_public_key_coordinates(
     key_content: &[u8],
     alg: Algorithm,
@@ -527,7 +527,7 @@ fn compute_digest(data: &[u8], hash_function: ThumbprintHash) -> Vec<u8> {
     digest::digest(algorithm, data).as_ref().to_vec()
 }
 
-#[cfg(feature = "rust_crypto")]
+#[cfg(all(not(feature = "aws_lc_rs"), feature = "rust_crypto"))]
 fn compute_digest(data: &[u8], hash_function: ThumbprintHash) -> Vec<u8> {
     match hash_function {
         ThumbprintHash::SHA256 => Sha256::digest(data).to_vec(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,6 @@
 
 #![deny(missing_docs)]
 
-#[cfg(all(feature = "rust_crypto", feature = "aws_lc_rs"))]
-compile_error!(
-    "feature \"rust_crypto\" and feature \"aws_lc_rs\" cannot be enabled at the same time"
-);
-
 #[cfg(not(any(feature = "rust_crypto", feature = "aws_lc_rs")))]
 compile_error!("at least one of the features \"rust_crypto\" or \"aws_lc_rs\" must be enabled");
 


### PR DESCRIPTION
This defaults to using aws's crypto lib if both features are enabled to make sure jsonwebtoken can be used

Genenrally everything should be re-written to make backend pluggable like in rustls, but this is the most simplest approach to work around issue of using jsonwebtoken in complex dependency tree