### PR TITLE
fix: bump minimal version requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ features = ["rust_crypto"]
 
 [dependencies]
 base64 = "0.22"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0"
 signature = { version = "2.2.0", features = ["std"] }
 
@@ -33,7 +33,7 @@ pem = { version = "3", optional = true }
 simple_asn1 = { version = "0.6", optional = true }
 
 # "aws_lc_rs" feature
-aws-lc-rs = { version = "1.10.0", optional = true }
+aws-lc-rs = { version = "1.15.0", optional = true }
 
 # "rust_crypto" feature
 ed25519-dalek = { version = "2.1.1", optional = true, features = ["pkcs8"] }


### PR DESCRIPTION
Before these changes this fails:

```
cargo minimal-versions check --no-default-features --features aws_lc_rs
```