### PR TITLE
security: zeroize encoding and decoding keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ p384 = { version = "0.13.0", optional = true, features = ["ecdsa"] }
 rand = { version = "0.8.5", optional = true, features = ["std"], default-features = false }
 rsa = { version = "0.9.6", optional = true }
 sha2 = { version = "0.10.7", optional = true, features = ["oid"] }
+zeroize = { version = "1.8.2", features = ["derive"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -2,6 +2,7 @@ use std::fmt::{Debug, Formatter};
 
 use base64::{Engine, engine::general_purpose::STANDARD};
 use serde::de::DeserializeOwned;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::algorithms::AlgorithmFamily;
 use crate::crypto::{CryptoProvider, JwtVerifier};
@@ -43,7 +44,7 @@ macro_rules! expect_two {
     }};
 }
 
-#[derive(Clone)]
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 /// Different kinds of decoding keys.
 pub enum DecodingKeyKind {
     /// A raw public key.
@@ -72,8 +73,9 @@ impl Debug for DecodingKeyKind {
 
 /// All the different kind of keys we can use to decode a JWT.
 /// This key can be re-used so make sure you only initialize it once if you can for better performance.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, ZeroizeOnDrop, Zeroize)]
 pub struct DecodingKey {
+    #[zeroize(skip)]
     family: AlgorithmFamily,
     kind: DecodingKeyKind,
 }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -5,6 +5,7 @@ use base64::{
     engine::general_purpose::{STANDARD, URL_SAFE},
 };
 use serde::ser::Serialize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::algorithms::AlgorithmFamily;
 use crate::crypto::CryptoProvider;
@@ -16,8 +17,9 @@ use crate::serialization::{b64_encode, b64_encode_part};
 
 /// A key to encode a JWT with. Can be a secret, a PEM-encoded key or a DER-encoded key.
 /// This key can be re-used so make sure you only initialize it once if you can for better performance.
-#[derive(Clone)]
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct EncodingKey {
+    #[zeroize(skip)]
     family: AlgorithmFamily,
     content: Vec<u8>,
 }


### PR DESCRIPTION
Addresses #337.

`PemEncodedKey` is still not zeroized and may contain sensistive data. Currently, it uses `simple_asn1` which does not support zeroize and also does not support parsing without taking ownership of the data.