### PR TITLE
Fix formatting in Ed25519 key serialization

### DIFF
--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -531,7 +531,7 @@ impl Jwk {
                 }
                 EllipticCurve::Ed25519 => {
                     format!(
-                        r#"{{crv:{},"kty":{},"x":"{}"}}"#,
+                        r#"{{"crv":{},"kty":{},"x":"{}"}}"#,
                         serde_json::to_string(&a.curve).unwrap(),
                         serde_json::to_string(&a.key_type).unwrap(),
                         a.x,


### PR DESCRIPTION
In the thumbprint() function, the serialized format of the Ed25519 curve is missing double quotes around "crv", which would likely affect interoperability between other implementations.

Fixes #484