### PR TITLE
fix: build wasm failed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ sha2 = { version = "0.10.7", optional = true, features = ["oid"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"
-getrandom = "0.2"
+getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.1"


### PR DESCRIPTION
Close #488

we need enable `js` feature on `getrandom` lib