### PR TITLE
Security: bump version of aws-lc-rs to 1.16.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ pem = { version = "3", optional = true }
 simple_asn1 = { version = "0.6", optional = true }
 
 # "aws_lc_rs" feature
-aws-lc-rs = { version = "1.15.0", optional = true }
+aws-lc-rs = { version = "1.16.1", optional = true }
 
 # "rust_crypto" feature
 ed25519-dalek = { version = "2.1.1", optional = true, features = ["pkcs8"] }


### PR DESCRIPTION
- https://github.com/aws/aws-lc-rs/commit/70d449ad1d1b4970a4d47114b80305589d285f23
- https://aws.amazon.com/security/security-bulletins/rss/2026-005-aws/