### PR TITLE
Bump minimum aws-lc-rs version to 1.16.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ pem = { version = "3", optional = true }
 simple_asn1 = { version = "0.6", optional = true }
 
 # "aws_lc_rs" feature
-aws-lc-rs = { version = "1.15.0", optional = true }
+aws-lc-rs = { version = "1.16.1", optional = true }
 
 # "rust_crypto" feature
 ed25519-dalek = { version = "2.1.1", optional = true, features = ["pkcs8"] }


### PR DESCRIPTION
Ensures downstream consumers pull in aws-lc-sys >= 0.38.0 which includes fixes for CVE-2026-3336 and CVE-2026-3338 (PKCS7_verify certificate chain and signature validation bypasses in AWS-LC).

jsonwebtoken does not use PKCS7 and is not directly affected, but bumping the minimum avoids pulling in a known-vulnerable transitive dependency.

Fixes https://github.com/Keats/jsonwebtoken/issues/491