### PR TITLE
ci: update `pinned` to Rust 1.88

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
                 include:
                     -   build: pinned
                         os: ubuntu-24.04
-                        rust: 1.86.0
+                        rust: 1.88.0
                     -   build: stable
                         os: ubuntu-latest
                         rust: stable


### PR DESCRIPTION
Required by new `time` crates (`time`, `time-core`, `time-macros`).