### PR TITLE
feat: add granular rust_crypto_* sub-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ aws-lc-rs = { version = "1.15.0", optional = true }
 
 # "rust_crypto" feature
 ed25519-dalek = { version = "2.1.1", optional = true, features = ["pkcs8"] }
-hmac = { version = "0.12.1", optional = true }
+hmac = { version = "0.12.1", optional = true, features = ["reset"] }
 p256 = { version = "0.13.2", optional = true, features = ["ecdsa"] }
 p384 = { version = "0.13.0", optional = true, features = ["ecdsa"] }
 rand = { version = "0.8.5", optional = true, features = ["std"], default-features = false }
@@ -67,8 +67,20 @@ criterion = { version = "0.8", default-features = false }
 [features]
 default = ["use_pem"]
 use_pem = ["dep:pem", "dep:simple_asn1"]
-rust_crypto = ["dep:ed25519-dalek", "dep:hmac", "dep:p256", "dep:p384", "dep:rand", "dep:rsa", "dep:sha2"]
+
+# Granular RustCrypto sub-features — enable only the algorithm families you need.
+# These are independent; combine freely. `rust_crypto` is a convenience alias for all of them.
+rust_crypto_rsa   = ["dep:rsa", "dep:sha2", "dep:rand"]  # RS256/384/512, PS256/384/512
+rust_crypto_ec    = ["dep:p256", "dep:p384", "dep:sha2"]  # ES256, ES384
+rust_crypto_eddsa = ["dep:ed25519-dalek"]                  # EdDSA
+rust_crypto_hmac  = ["dep:hmac", "dep:sha2"]               # HS256/384/512
+
+# Enables all RustCrypto algorithm families above (unchanged behaviour).
+rust_crypto = ["rust_crypto_rsa", "rust_crypto_ec", "rust_crypto_eddsa", "rust_crypto_hmac"]
+
 aws_lc_rs = ["dep:aws-lc-rs"]
+
+[workspace]
 
 [[bench]]
 name = "jwt"

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -19,7 +19,13 @@ use crate::{DecodingKey, EncodingKey};
 pub mod aws_lc;
 
 /// `RustCrypto` based CryptoProvider.
-#[cfg(feature = "rust_crypto")]
+#[cfg(any(
+    feature = "rust_crypto",
+    feature = "rust_crypto_rsa",
+    feature = "rust_crypto_ec",
+    feature = "rust_crypto_eddsa",
+    feature = "rust_crypto_hmac",
+))]
 pub mod rust_crypto;
 
 use crate::serialization::{b64_decode, b64_encode};
@@ -102,12 +108,27 @@ impl CryptoProvider {
     }
 
     fn from_crate_features() -> &'static Self {
-        #[cfg(all(feature = "rust_crypto", not(feature = "aws_lc_rs")))]
+        #[cfg(all(
+            any(
+                feature = "rust_crypto",
+                feature = "rust_crypto_rsa",
+                feature = "rust_crypto_ec",
+                feature = "rust_crypto_eddsa",
+                feature = "rust_crypto_hmac",
+            ),
+            not(feature = "aws_lc_rs")
+        ))]
         {
             return &rust_crypto::DEFAULT_PROVIDER;
         }
 
-        #[cfg(all(feature = "aws_lc_rs", not(feature = "rust_crypto")))]
+        #[cfg(all(feature = "aws_lc_rs", not(any(
+            feature = "rust_crypto",
+            feature = "rust_crypto_rsa",
+            feature = "rust_crypto_ec",
+            feature = "rust_crypto_eddsa",
+            feature = "rust_crypto_hmac",
+        ))))]
         {
             return &aws_lc::DEFAULT_PROVIDER;
         }

--- a/src/crypto/rust_crypto/ecdsa.rs
+++ b/src/crypto/rust_crypto/ecdsa.rs
@@ -11,7 +11,7 @@ use p256::ecdsa::{
 use p384::ecdsa::{
     Signature as Signature384, SigningKey as SigningKey384, VerifyingKey as VerifyingKey384,
 };
-use rsa::pkcs8::DecodePrivateKey;
+use p256::pkcs8::DecodePrivateKey;
 use signature::{Error, Signer, Verifier};
 
 macro_rules! define_ecdsa_signer {

--- a/src/crypto/rust_crypto/mod.rs
+++ b/src/crypto/rust_crypto/mod.rs
@@ -1,82 +1,140 @@
+#[cfg(any(feature = "rust_crypto", feature = "rust_crypto_rsa"))]
 use ::rsa::{RsaPrivateKey, pkcs1::DecodeRsaPrivateKey, traits::PublicKeyParts};
+
+#[cfg(any(feature = "rust_crypto", feature = "rust_crypto_ec"))]
 use p256::{ecdsa::SigningKey as P256SigningKey, pkcs8::DecodePrivateKey};
+#[cfg(any(feature = "rust_crypto", feature = "rust_crypto_ec"))]
 use p384::ecdsa::SigningKey as P384SigningKey;
+
+#[cfg(any(
+    feature = "rust_crypto",
+    feature = "rust_crypto_rsa",
+    feature = "rust_crypto_ec",
+    feature = "rust_crypto_hmac",
+))]
 use sha2::{Digest, Sha256, Sha384, Sha512};
 
 use crate::{
     Algorithm, DecodingKey, EncodingKey,
     crypto::{CryptoProvider, JwkUtils, JwtSigner, JwtVerifier},
-    errors::{self, Error, ErrorKind},
+    errors::{self, Error, ErrorKind, new_error},
     jwk::{EllipticCurve, ThumbprintHash},
 };
 
+#[cfg(any(feature = "rust_crypto", feature = "rust_crypto_ec"))]
 mod ecdsa;
+#[cfg(any(feature = "rust_crypto", feature = "rust_crypto_eddsa"))]
 mod eddsa;
+#[cfg(any(feature = "rust_crypto", feature = "rust_crypto_hmac"))]
 mod hmac;
+#[cfg(any(feature = "rust_crypto", feature = "rust_crypto_rsa"))]
 mod rsa;
 
 fn extract_rsa_public_key_components(key_content: &[u8]) -> errors::Result<(Vec<u8>, Vec<u8>)> {
-    let private_key = RsaPrivateKey::from_pkcs1_der(key_content)
-        .map_err(|e| ErrorKind::InvalidRsaKey(e.to_string()))?;
-    let public_key = private_key.to_public_key();
-    Ok((public_key.n().to_bytes_be(), public_key.e().to_bytes_be()))
+    #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_rsa"))]
+    {
+        let private_key = RsaPrivateKey::from_pkcs1_der(key_content)
+            .map_err(|e| ErrorKind::InvalidRsaKey(e.to_string()))?;
+        let public_key = private_key.to_public_key();
+        return Ok((public_key.n().to_bytes_be(), public_key.e().to_bytes_be()));
+    }
+    #[allow(unreachable_code)]
+    {
+        let _ = key_content;
+        Err(new_error(ErrorKind::UnsupportedAlgorithm))
+    }
 }
 
 fn extract_ec_public_key_coordinates(
     key_content: &[u8],
     alg: Algorithm,
 ) -> errors::Result<(EllipticCurve, Vec<u8>, Vec<u8>)> {
-    match alg {
-        Algorithm::ES256 => {
-            let signing_key = P256SigningKey::from_pkcs8_der(key_content)
-                .map_err(|_| ErrorKind::InvalidEcdsaKey)?;
-            let public_key = signing_key.verifying_key();
-            let encoded = public_key.to_encoded_point(false);
-            match encoded.coordinates() {
-                p256::elliptic_curve::sec1::Coordinates::Uncompressed { x, y } => {
-                    Ok((EllipticCurve::P256, x.to_vec(), y.to_vec()))
+    #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_ec"))]
+    {
+        return match alg {
+            Algorithm::ES256 => {
+                let signing_key = P256SigningKey::from_pkcs8_der(key_content)
+                    .map_err(|_| ErrorKind::InvalidEcdsaKey)?;
+                let public_key = signing_key.verifying_key();
+                let encoded = public_key.to_encoded_point(false);
+                match encoded.coordinates() {
+                    p256::elliptic_curve::sec1::Coordinates::Uncompressed { x, y } => {
+                        Ok((EllipticCurve::P256, x.to_vec(), y.to_vec()))
+                    }
+                    _ => Err(ErrorKind::InvalidEcdsaKey.into()),
                 }
-                _ => Err(ErrorKind::InvalidEcdsaKey.into()),
             }
-        }
-        Algorithm::ES384 => {
-            let signing_key = P384SigningKey::from_pkcs8_der(key_content)
-                .map_err(|_| ErrorKind::InvalidEcdsaKey)?;
-            let public_key = signing_key.verifying_key();
-            let encoded = public_key.to_encoded_point(false);
-            match encoded.coordinates() {
-                p384::elliptic_curve::sec1::Coordinates::Uncompressed { x, y } => {
-                    Ok((EllipticCurve::P384, x.to_vec(), y.to_vec()))
+            Algorithm::ES384 => {
+                let signing_key = P384SigningKey::from_pkcs8_der(key_content)
+                    .map_err(|_| ErrorKind::InvalidEcdsaKey)?;
+                let public_key = signing_key.verifying_key();
+                let encoded = public_key.to_encoded_point(false);
+                match encoded.coordinates() {
+                    p384::elliptic_curve::sec1::Coordinates::Uncompressed { x, y } => {
+                        Ok((EllipticCurve::P384, x.to_vec(), y.to_vec()))
+                    }
+                    _ => Err(ErrorKind::InvalidEcdsaKey.into()),
                 }
-                _ => Err(ErrorKind::InvalidEcdsaKey.into()),
             }
-        }
-        _ => Err(ErrorKind::InvalidEcdsaKey.into()),
+            _ => Err(ErrorKind::InvalidEcdsaKey.into()),
+        };
+    }
+    #[allow(unreachable_code)]
+    {
+        let _ = (key_content, alg);
+        Err(new_error(ErrorKind::UnsupportedAlgorithm))
     }
 }
 
 fn compute_digest(data: &[u8], hash_function: ThumbprintHash) -> errors::Result<Vec<u8>> {
-    Ok(match hash_function {
-        ThumbprintHash::SHA256 => Sha256::digest(data).to_vec(),
-        ThumbprintHash::SHA384 => Sha384::digest(data).to_vec(),
-        ThumbprintHash::SHA512 => Sha512::digest(data).to_vec(),
-    })
+    #[cfg(any(
+        feature = "rust_crypto",
+        feature = "rust_crypto_rsa",
+        feature = "rust_crypto_ec",
+        feature = "rust_crypto_hmac",
+    ))]
+    {
+        return Ok(match hash_function {
+            ThumbprintHash::SHA256 => Sha256::digest(data).to_vec(),
+            ThumbprintHash::SHA384 => Sha384::digest(data).to_vec(),
+            ThumbprintHash::SHA512 => Sha512::digest(data).to_vec(),
+        });
+    }
+    #[allow(unreachable_code)]
+    {
+        let _ = (data, hash_function);
+        Err(new_error(ErrorKind::UnsupportedAlgorithm))
+    }
 }
 
 fn new_signer(algorithm: &Algorithm, key: &EncodingKey) -> Result<Box<dyn JwtSigner>, Error> {
-    let jwt_signer = match algorithm {
+    #[allow(unreachable_patterns)]
+    let jwt_signer: Box<dyn JwtSigner> = match algorithm {
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_hmac"))]
         Algorithm::HS256 => Box::new(hmac::Hs256Signer::new(key)?) as Box<dyn JwtSigner>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_hmac"))]
         Algorithm::HS384 => Box::new(hmac::Hs384Signer::new(key)?) as Box<dyn JwtSigner>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_hmac"))]
         Algorithm::HS512 => Box::new(hmac::Hs512Signer::new(key)?) as Box<dyn JwtSigner>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_ec"))]
         Algorithm::ES256 => Box::new(ecdsa::Es256Signer::new(key)?) as Box<dyn JwtSigner>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_ec"))]
         Algorithm::ES384 => Box::new(ecdsa::Es384Signer::new(key)?) as Box<dyn JwtSigner>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_rsa"))]
         Algorithm::RS256 => Box::new(rsa::Rsa256Signer::new(key)?) as Box<dyn JwtSigner>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_rsa"))]
         Algorithm::RS384 => Box::new(rsa::Rsa384Signer::new(key)?) as Box<dyn JwtSigner>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_rsa"))]
         Algorithm::RS512 => Box::new(rsa::Rsa512Signer::new(key)?) as Box<dyn JwtSigner>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_rsa"))]
         Algorithm::PS256 => Box::new(rsa::RsaPss256Signer::new(key)?) as Box<dyn JwtSigner>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_rsa"))]
         Algorithm::PS384 => Box::new(rsa::RsaPss384Signer::new(key)?) as Box<dyn JwtSigner>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_rsa"))]
         Algorithm::PS512 => Box::new(rsa::RsaPss512Signer::new(key)?) as Box<dyn JwtSigner>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_eddsa"))]
         Algorithm::EdDSA => Box::new(eddsa::EdDSASigner::new(key)?) as Box<dyn JwtSigner>,
+        _ => return Err(new_error(ErrorKind::UnsupportedAlgorithm)),
     };
 
     Ok(jwt_signer)
@@ -86,19 +144,33 @@ fn new_verifier(
     algorithm: &Algorithm,
     key: &DecodingKey,
 ) -> Result<Box<dyn super::JwtVerifier>, Error> {
-    let jwt_verifier = match algorithm {
+    #[allow(unreachable_patterns)]
+    let jwt_verifier: Box<dyn JwtVerifier> = match algorithm {
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_hmac"))]
         Algorithm::HS256 => Box::new(hmac::Hs256Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_hmac"))]
         Algorithm::HS384 => Box::new(hmac::Hs384Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_hmac"))]
         Algorithm::HS512 => Box::new(hmac::Hs512Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_ec"))]
         Algorithm::ES256 => Box::new(ecdsa::Es256Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_ec"))]
         Algorithm::ES384 => Box::new(ecdsa::Es384Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_rsa"))]
         Algorithm::RS256 => Box::new(rsa::Rsa256Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_rsa"))]
         Algorithm::RS384 => Box::new(rsa::Rsa384Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_rsa"))]
         Algorithm::RS512 => Box::new(rsa::Rsa512Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_rsa"))]
         Algorithm::PS256 => Box::new(rsa::RsaPss256Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_rsa"))]
         Algorithm::PS384 => Box::new(rsa::RsaPss384Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_rsa"))]
         Algorithm::PS512 => Box::new(rsa::RsaPss512Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        #[cfg(any(feature = "rust_crypto", feature = "rust_crypto_eddsa"))]
         Algorithm::EdDSA => Box::new(eddsa::EdDSAVerifier::new(key)?) as Box<dyn JwtVerifier>,
+        _ => return Err(new_error(ErrorKind::UnsupportedAlgorithm)),
     };
 
     Ok(jwt_verifier)

--- a/src/crypto/rust_crypto/rsa.rs
+++ b/src/crypto/rust_crypto/rsa.rs
@@ -1,7 +1,7 @@
 //! Implementations of the [`JwtSigner`] and [`JwtVerifier`] traits for the
 //! RSA family of algorithms using RustCrypto.
 
-use hmac::digest::FixedOutputReset;
+use sha2::digest::FixedOutputReset;
 use rsa::{
     BigUint, Pkcs1v15Sign, Pss, RsaPublicKey,
     pkcs1::{DecodeRsaPrivateKey, DecodeRsaPublicKey},


### PR DESCRIPTION
This got a bit bigger than I'd like, but submitting this anyway in case you find it useful.

`rust_crypto` is currently an all-or-nothing bundle that pulls in seven crates (ed25519-dalek, hmac, p256, p384, rand, rsa, sha2) even when an application only needs one algorithm family. This PR adds four independent sub-features that let users opt into a family:

  rust_crypto_rsa   — RS256/384/512, PS256/384/512  (rsa + sha2 + rand)
  rust_crypto_ec    — ES256, ES384                   (p256 + p384 + sha2)
  rust_crypto_eddsa — EdDSA                          (ed25519-dalek)
  rust_crypto_hmac  — HS256/384/512                  (hmac + sha2)

`rust_crypto` effectively remains unchanged. Requesting an unsupported algorithm at runtime (one whose feature is not enabled) returns `ErrorKind::UnsupportedAlgorithm`.

Three latent issues were fixed as prerequisites, all semantically equivalent to the original behaviour:

- rsa.rs: `FixedOutputReset` was imported via `hmac::digest`. Changed to `sha2::digest`. Both re-export `digest v0.10.7` — same crate instance, same trait identity — so this is a no-op for existing builds, but removes the undeclared dependency on the hmac crate from the RSA path.

- ecdsa.rs: `DecodePrivateKey` was imported via `rsa::pkcs8`. Changed to `p256::pkcs8`. Both re-export `pkcs8 v0.10.x` at the same resolved version, so the trait identity is identical. This removes the undeclared dependency on the rsa crate from the EC path.

- hmac dep: `features = ["reset"]` is now declared explicitly. Previously the `reset` feature (which provides the `Reset` impl required by `Mac::reset()` in hmac.rs) was activated only because the rsa crate happened to pull it in transitively. The code always required it; this makes the requirement explicit and prevents a silent future breakage if rsa ever stops being a transitive enabler.