### PR TITLE
feat: add OpenSSL support for JWT signing and verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                backend: [ aws_lc_rs, rust_crypto ]
+                backend: [ aws_lc_rs, rust_crypto, openssl ]
         steps:
             -   uses: actions/checkout@v3
             -   uses: dtolnay/rust-toolchain@stable
@@ -37,7 +37,7 @@ jobs:
         strategy:
             matrix:
                 build: [ pinned, stable, nightly ]
-                backend: [ aws_lc_rs, rust_crypto ]
+                backend: [ aws_lc_rs, rust_crypto, openssl ]
                 include:
                     -   build: pinned
                         os: ubuntu-24.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ simple_asn1 = { version = "0.6", optional = true }
 # "aws_lc_rs" feature
 aws-lc-rs = { version = "1.15.0", optional = true }
 
+# "openssl" feature
+openssl = { version = "0.10.57", optional = true }
+
 # "rust_crypto" feature
 ed25519-dalek = { version = "2.1.1", optional = true, features = ["pkcs8"] }
 hmac = { version = "0.12.1", optional = true }
@@ -69,6 +72,7 @@ default = ["use_pem"]
 use_pem = ["dep:pem", "dep:simple_asn1"]
 rust_crypto = ["dep:ed25519-dalek", "dep:hmac", "dep:p256", "dep:p384", "dep:rand", "dep:rsa", "dep:sha2"]
 aws_lc_rs = ["dep:aws-lc-rs"]
+openssl = ["dep:openssl"]
 
 [[bench]]
 name = "jwt"

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -18,6 +18,10 @@ use crate::{DecodingKey, EncodingKey};
 #[cfg(feature = "aws_lc_rs")]
 pub mod aws_lc;
 
+/// `openssl` based CryptoProvider.
+#[cfg(feature = "openssl")]
+pub mod openssl;
+
 /// `RustCrypto` based CryptoProvider.
 #[cfg(feature = "rust_crypto")]
 pub mod rust_crypto;
@@ -73,6 +77,8 @@ pub fn verify(
 /// You can either install one of the built-in options:
 /// - [`crypto::aws_lc::DEFAULT_PROVIDER`]: (behind the `aws_lc_rs` crate feature).
 ///   This provider uses the [aws-lc-rs](https://github.com/aws/aws-lc-rs) crate.
+/// - [`crypto::openssl::DEFAULT_PROVIDER`]: (behind the `openssl` crate feature).
+///   This provider uses the [openssl](https://github.com/sfackler/rust-openssl) crate.
 /// - [`crypto::rust_crypto::DEFAULT_PROVIDER`]: (behind the `rust_crypto` crate feature)
 ///   This provider uses crates from the [Rust Crypto](https://github.com/RustCrypto) project.
 ///
@@ -102,21 +108,38 @@ impl CryptoProvider {
     }
 
     fn from_crate_features() -> &'static Self {
-        #[cfg(all(feature = "rust_crypto", not(feature = "aws_lc_rs")))]
+        #[cfg(all(
+            feature = "rust_crypto",
+            not(feature = "aws_lc_rs"),
+            not(feature = "openssl")
+        ))]
         {
             return &rust_crypto::DEFAULT_PROVIDER;
         }
 
-        #[cfg(all(feature = "aws_lc_rs", not(feature = "rust_crypto")))]
+        #[cfg(all(
+            feature = "aws_lc_rs",
+            not(feature = "rust_crypto"),
+            not(feature = "openssl")
+        ))]
         {
             return &aws_lc::DEFAULT_PROVIDER;
+        }
+
+        #[cfg(all(
+            feature = "openssl",
+            not(feature = "rust_crypto"),
+            not(feature = "aws_lc_rs")
+        ))]
+        {
+            return &openssl::DEFAULT_PROVIDER;
         }
 
         #[allow(unreachable_code)]
         {
             const NOT_INSTALLED_ERROR: &str = r"
 Could not automatically determine the process-level CryptoProvider from jsonwebtoken crate features.
-Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'rust_crypto' and 'aws_lc_rs' features is enabled.
+Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'rust_crypto', 'aws_lc_rs', and 'openssl' features is enabled.
 See the documentation of the CryptoProvider type for more information.
 ";
 
@@ -156,7 +179,7 @@ impl KeyUtils {
     pub const fn new_unimplemented() -> Self {
         const NOT_INSTALLED_OR_UNIMPLEMENTED_ERROR: &str = r"
 Could not automatically determine the process-level CryptoProvider from jsonwebtoken crate features, or your CryptoProvider does not support JWKs.
-Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'rust_crypto' and 'aws_lc_rs' features is enabled.
+Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'rust_crypto', 'aws_lc_rs', and 'openssl' features is enabled.
 See the documentation of the CryptoProvider type for more information.
 ";
         Self {

--- a/src/crypto/openssl/ecdsa.rs
+++ b/src/crypto/openssl/ecdsa.rs
@@ -1,0 +1,127 @@
+//! Implementations of the [`JwtSigner`] and [`JwtVerifier`] traits for the
+//! ECDSA family of algorithms using `openssl`.
+
+use openssl::bn::{BigNum, BigNumContext};
+use openssl::ec::{EcGroup, EcKey, EcPoint};
+use openssl::ecdsa::EcdsaSig;
+use openssl::hash::MessageDigest;
+use openssl::nid::Nid;
+use openssl::pkey::PKey;
+use openssl::sign::{Signer as OsslSigner, Verifier as OsslVerifier};
+use signature::{Error, Signer, Verifier};
+
+use crate::algorithms::AlgorithmFamily;
+use crate::crypto::{JwtSigner, JwtVerifier};
+use crate::errors::{ErrorKind, Result, new_error};
+use crate::{Algorithm, DecodingKey, EncodingKey};
+
+macro_rules! define_ecdsa_signer {
+    ($name:ident, $alg:expr, $digest:expr, $field_size:expr) => {
+        pub struct $name(PKey<openssl::pkey::Private>);
+
+        impl $name {
+            pub(crate) fn new(encoding_key: &EncodingKey) -> Result<Self> {
+                if encoding_key.family() != AlgorithmFamily::Ec {
+                    return Err(new_error(ErrorKind::InvalidKeyFormat));
+                }
+
+                let pkey = PKey::private_key_from_der(encoding_key.inner())
+                    .map_err(|_| ErrorKind::InvalidEcdsaKey)?;
+                Ok(Self(pkey))
+            }
+        }
+
+        impl Signer<Vec<u8>> for $name {
+            fn try_sign(&self, msg: &[u8]) -> std::result::Result<Vec<u8>, Error> {
+                let mut signer =
+                    OsslSigner::new($digest, &self.0).map_err(Error::from_source)?;
+                signer.update(msg).map_err(Error::from_source)?;
+                let der_sig = signer.sign_to_vec().map_err(Error::from_source)?;
+
+                // Convert DER-encoded signature to fixed-length (r || s) format for JWT
+                let ecdsa_sig = EcdsaSig::from_der(&der_sig).map_err(Error::from_source)?;
+                let r = ecdsa_sig
+                    .r()
+                    .to_vec_padded($field_size)
+                    .map_err(Error::from_source)?;
+                let s = ecdsa_sig
+                    .s()
+                    .to_vec_padded($field_size)
+                    .map_err(Error::from_source)?;
+
+                let mut fixed_sig = Vec::with_capacity($field_size * 2);
+                fixed_sig.extend_from_slice(&r);
+                fixed_sig.extend_from_slice(&s);
+                Ok(fixed_sig)
+            }
+        }
+
+        impl JwtSigner for $name {
+            fn algorithm(&self) -> Algorithm {
+                $alg
+            }
+        }
+    };
+}
+
+macro_rules! define_ecdsa_verifier {
+    ($name:ident, $alg:expr, $digest:expr, $nid:expr, $field_size:expr) => {
+        pub struct $name(DecodingKey);
+
+        impl $name {
+            pub(crate) fn new(decoding_key: &DecodingKey) -> Result<Self> {
+                if decoding_key.family() != AlgorithmFamily::Ec {
+                    return Err(new_error(ErrorKind::InvalidKeyFormat));
+                }
+
+                Ok(Self(decoding_key.clone()))
+            }
+        }
+
+        impl Verifier<Vec<u8>> for $name {
+            fn verify(
+                &self,
+                msg: &[u8],
+                signature: &Vec<u8>,
+            ) -> std::result::Result<(), Error> {
+                // Reconstruct EC public key from SEC1 uncompressed point bytes
+                let group = EcGroup::from_curve_name($nid).map_err(Error::from_source)?;
+                let mut ctx = BigNumContext::new().map_err(Error::from_source)?;
+                let point = EcPoint::from_bytes(&group, self.0.as_bytes(), &mut ctx)
+                    .map_err(Error::from_source)?;
+                let ec_key =
+                    EcKey::from_public_key(&group, &point).map_err(Error::from_source)?;
+                let pkey = PKey::from_ec_key(ec_key).map_err(Error::from_source)?;
+
+                // Convert fixed-length (r || s) signature to DER format
+                let (r_bytes, s_bytes) = signature.split_at($field_size);
+                let r = BigNum::from_slice(r_bytes).map_err(Error::from_source)?;
+                let s = BigNum::from_slice(s_bytes).map_err(Error::from_source)?;
+                let ecdsa_sig =
+                    EcdsaSig::from_private_components(r, s).map_err(Error::from_source)?;
+                let der_sig = ecdsa_sig.to_der().map_err(Error::from_source)?;
+
+                let mut verifier =
+                    OsslVerifier::new($digest, &pkey).map_err(Error::from_source)?;
+                verifier.update(msg).map_err(Error::from_source)?;
+                if verifier.verify(&der_sig).map_err(Error::from_source)? {
+                    Ok(())
+                } else {
+                    Err(Error::new())
+                }
+            }
+        }
+
+        impl JwtVerifier for $name {
+            fn algorithm(&self) -> Algorithm {
+                $alg
+            }
+        }
+    };
+}
+
+define_ecdsa_signer!(Es256Signer, Algorithm::ES256, MessageDigest::sha256(), 32);
+define_ecdsa_signer!(Es384Signer, Algorithm::ES384, MessageDigest::sha384(), 48);
+
+define_ecdsa_verifier!(Es256Verifier, Algorithm::ES256, MessageDigest::sha256(), Nid::X9_62_PRIME256V1, 32);
+define_ecdsa_verifier!(Es384Verifier, Algorithm::ES384, MessageDigest::sha384(), Nid::SECP384R1, 48);

--- a/src/crypto/openssl/eddsa.rs
+++ b/src/crypto/openssl/eddsa.rs
@@ -1,0 +1,75 @@
+//! Implementations of the [`JwtSigner`] and [`JwtVerifier`] traits for EdDSA using `openssl`.
+
+use openssl::pkey::{Id, PKey};
+use openssl::sign::{Signer as OsslSigner, Verifier as OsslVerifier};
+use signature::{Error, Signer, Verifier};
+
+use crate::algorithms::AlgorithmFamily;
+use crate::crypto::{JwtSigner, JwtVerifier};
+use crate::errors::{ErrorKind, Result, new_error};
+use crate::{Algorithm, DecodingKey, EncodingKey};
+
+pub struct EdDSASigner(PKey<openssl::pkey::Private>);
+
+impl EdDSASigner {
+    pub(crate) fn new(encoding_key: &EncodingKey) -> Result<Self> {
+        if encoding_key.family() != AlgorithmFamily::Ed {
+            return Err(new_error(ErrorKind::InvalidKeyFormat));
+        }
+
+        let pkey = PKey::private_key_from_der(encoding_key.inner())
+            .map_err(|_| ErrorKind::InvalidEddsaKey)?;
+        Ok(Self(pkey))
+    }
+}
+
+impl Signer<Vec<u8>> for EdDSASigner {
+    fn try_sign(&self, msg: &[u8]) -> std::result::Result<Vec<u8>, Error> {
+        let mut signer =
+            OsslSigner::new_without_digest(&self.0).map_err(Error::from_source)?;
+        signer
+            .sign_oneshot_to_vec(msg)
+            .map_err(Error::from_source)
+    }
+}
+
+impl JwtSigner for EdDSASigner {
+    fn algorithm(&self) -> Algorithm {
+        Algorithm::EdDSA
+    }
+}
+
+pub struct EdDSAVerifier(DecodingKey);
+
+impl EdDSAVerifier {
+    pub(crate) fn new(decoding_key: &DecodingKey) -> Result<Self> {
+        if decoding_key.family() != AlgorithmFamily::Ed {
+            return Err(new_error(ErrorKind::InvalidKeyFormat));
+        }
+
+        Ok(Self(decoding_key.clone()))
+    }
+}
+
+impl Verifier<Vec<u8>> for EdDSAVerifier {
+    fn verify(&self, msg: &[u8], signature: &Vec<u8>) -> std::result::Result<(), Error> {
+        let pkey = PKey::public_key_from_raw_bytes(self.0.as_bytes(), Id::ED25519)
+            .map_err(Error::from_source)?;
+        let mut verifier =
+            OsslVerifier::new_without_digest(&pkey).map_err(Error::from_source)?;
+        if verifier
+            .verify_oneshot(signature, msg)
+            .map_err(Error::from_source)?
+        {
+            Ok(())
+        } else {
+            Err(Error::new())
+        }
+    }
+}
+
+impl JwtVerifier for EdDSAVerifier {
+    fn algorithm(&self) -> Algorithm {
+        Algorithm::EdDSA
+    }
+}

--- a/src/crypto/openssl/hmac.rs
+++ b/src/crypto/openssl/hmac.rs
@@ -1,0 +1,91 @@
+//! Implementations of the [`JwtSigner`] and [`JwtVerifier`] traits for the
+//! HMAC family of algorithms using `openssl`.
+
+use openssl::hash::MessageDigest;
+use openssl::memcmp;
+use openssl::pkey::PKey;
+use openssl::sign::Signer as OsslSigner;
+use signature::{Signer, Verifier};
+
+use crate::crypto::{JwtSigner, JwtVerifier};
+use crate::errors::Result;
+use crate::{Algorithm, DecodingKey, EncodingKey};
+
+macro_rules! define_hmac_signer {
+    ($name:ident, $alg:expr, $digest_fn:expr) => {
+        pub struct $name(EncodingKey);
+
+        impl $name {
+            pub(crate) fn new(encoding_key: &EncodingKey) -> Result<Self> {
+                encoding_key.try_get_hmac_secret()?;
+                Ok(Self(encoding_key.clone()))
+            }
+        }
+
+        impl Signer<Vec<u8>> for $name {
+            fn try_sign(&self, msg: &[u8]) -> std::result::Result<Vec<u8>, signature::Error> {
+                let secret = self.0.try_get_hmac_secret().map_err(signature::Error::from_source)?;
+                let pkey = PKey::hmac(secret).map_err(signature::Error::from_source)?;
+                let mut signer =
+                    OsslSigner::new($digest_fn, &pkey).map_err(signature::Error::from_source)?;
+                signer.update(msg).map_err(signature::Error::from_source)?;
+                signer.sign_to_vec().map_err(signature::Error::from_source)
+            }
+        }
+
+        impl JwtSigner for $name {
+            fn algorithm(&self) -> Algorithm {
+                $alg
+            }
+        }
+    };
+}
+
+macro_rules! define_hmac_verifier {
+    ($name:ident, $alg:expr, $digest_fn:expr) => {
+        pub struct $name(DecodingKey);
+
+        impl $name {
+            pub(crate) fn new(decoding_key: &DecodingKey) -> Result<Self> {
+                decoding_key.try_get_hmac_secret()?;
+                Ok(Self(decoding_key.clone()))
+            }
+        }
+
+        impl Verifier<Vec<u8>> for $name {
+            fn verify(
+                &self,
+                msg: &[u8],
+                signature: &Vec<u8>,
+            ) -> std::result::Result<(), signature::Error> {
+                let secret =
+                    self.0.try_get_hmac_secret().map_err(signature::Error::from_source)?;
+                let pkey = PKey::hmac(secret).map_err(signature::Error::from_source)?;
+                let mut signer =
+                    OsslSigner::new($digest_fn, &pkey).map_err(signature::Error::from_source)?;
+                signer.update(msg).map_err(signature::Error::from_source)?;
+                let computed = signer.sign_to_vec().map_err(signature::Error::from_source)?;
+
+                if memcmp::eq(&computed, signature) {
+                    Ok(())
+                } else {
+                    Err(signature::Error::new())
+                }
+            }
+        }
+
+        impl JwtVerifier for $name {
+            fn algorithm(&self) -> Algorithm {
+                $alg
+            }
+        }
+    };
+}
+
+define_hmac_signer!(Hs256Signer, Algorithm::HS256, MessageDigest::sha256());
+define_hmac_signer!(Hs384Signer, Algorithm::HS384, MessageDigest::sha384());
+define_hmac_signer!(Hs512Signer, Algorithm::HS512, MessageDigest::sha512());
+
+define_hmac_verifier!(Hs256Verifier, Algorithm::HS256, MessageDigest::sha256());
+define_hmac_verifier!(Hs384Verifier, Algorithm::HS384, MessageDigest::sha384());
+define_hmac_verifier!(Hs512Verifier, Algorithm::HS512, MessageDigest::sha512());

--- a/src/crypto/openssl/mod.rs
+++ b/src/crypto/openssl/mod.rs
@@ -1,0 +1,129 @@
+//! `openssl` based [`CryptoProvider`].
+
+use openssl::bn::BigNumContext;
+use openssl::ec::{EcGroup, PointConversionForm};
+use openssl::hash::MessageDigest;
+use openssl::nid::Nid;
+use openssl::pkey::PKey;
+use openssl::rsa::Rsa;
+
+use crate::{
+    Algorithm, DecodingKey, EncodingKey,
+    crypto::{CryptoProvider, JwtSigner, JwtVerifier, KeyUtils},
+    errors::{self, Error, ErrorKind},
+    jwk::{EllipticCurve, ThumbprintHash},
+};
+
+mod ecdsa;
+mod eddsa;
+mod hmac;
+mod rsa;
+
+fn rsa_components_from_private_key(key_content: &[u8]) -> errors::Result<(Vec<u8>, Vec<u8>)> {
+    let rsa_key = Rsa::private_key_from_der(key_content)
+        .map_err(|e| ErrorKind::InvalidRsaKey(e.to_string()))?;
+    let n = rsa_key.n().to_vec();
+    let e = rsa_key.e().to_vec();
+    Ok((n, e))
+}
+
+fn rsa_components_from_public_key(key_content: &[u8]) -> errors::Result<(Vec<u8>, Vec<u8>)> {
+    let rsa_key = Rsa::public_key_from_der_pkcs1(key_content)
+        .map_err(|e| ErrorKind::InvalidRsaKey(e.to_string()))?;
+    let n = rsa_key.n().to_vec();
+    let e = rsa_key.e().to_vec();
+    Ok((n, e))
+}
+
+fn ec_components_from_private_key(
+    key_content: &[u8],
+    alg: Algorithm,
+) -> errors::Result<(EllipticCurve, Vec<u8>, Vec<u8>)> {
+    let (curve, nid, field_size) = match alg {
+        Algorithm::ES256 => (EllipticCurve::P256, Nid::X9_62_PRIME256V1, 32),
+        Algorithm::ES384 => (EllipticCurve::P384, Nid::SECP384R1, 48),
+        _ => return Err(ErrorKind::InvalidEcdsaKey.into()),
+    };
+
+    let pkey = PKey::private_key_from_der(key_content)
+        .map_err(|_| ErrorKind::InvalidEcdsaKey)?;
+    let ec_key = pkey.ec_key().map_err(|_| ErrorKind::InvalidEcdsaKey)?;
+
+    let group = EcGroup::from_curve_name(nid).map_err(|_| ErrorKind::InvalidEcdsaKey)?;
+    let mut ctx = BigNumContext::new().map_err(|_| ErrorKind::InvalidEcdsaKey)?;
+    let pub_bytes = ec_key
+        .public_key()
+        .to_bytes(&group, PointConversionForm::UNCOMPRESSED, &mut ctx)
+        .map_err(|_| ErrorKind::InvalidEcdsaKey)?;
+
+    if pub_bytes[0] != 4 || pub_bytes.len() != 1 + field_size * 2 {
+        return Err(ErrorKind::InvalidEcdsaKey.into());
+    }
+
+    let (x, y) = pub_bytes[1..].split_at(field_size);
+    Ok((curve, x.to_vec(), y.to_vec()))
+}
+
+fn compute_digest(data: &[u8], hash_function: ThumbprintHash) -> errors::Result<Vec<u8>> {
+    let digest_type = match hash_function {
+        ThumbprintHash::SHA256 => MessageDigest::sha256(),
+        ThumbprintHash::SHA384 => MessageDigest::sha384(),
+        ThumbprintHash::SHA512 => MessageDigest::sha512(),
+    };
+    Ok(openssl::hash::hash(digest_type, data)
+        .map_err(|e| ErrorKind::Provider(e.to_string()))?
+        .to_vec())
+}
+
+fn new_signer(algorithm: &Algorithm, key: &EncodingKey) -> Result<Box<dyn JwtSigner>, Error> {
+    let jwt_signer = match algorithm {
+        Algorithm::HS256 => Box::new(hmac::Hs256Signer::new(key)?) as Box<dyn JwtSigner>,
+        Algorithm::HS384 => Box::new(hmac::Hs384Signer::new(key)?) as Box<dyn JwtSigner>,
+        Algorithm::HS512 => Box::new(hmac::Hs512Signer::new(key)?) as Box<dyn JwtSigner>,
+        Algorithm::ES256 => Box::new(ecdsa::Es256Signer::new(key)?) as Box<dyn JwtSigner>,
+        Algorithm::ES384 => Box::new(ecdsa::Es384Signer::new(key)?) as Box<dyn JwtSigner>,
+        Algorithm::RS256 => Box::new(rsa::Rsa256Signer::new(key)?) as Box<dyn JwtSigner>,
+        Algorithm::RS384 => Box::new(rsa::Rsa384Signer::new(key)?) as Box<dyn JwtSigner>,
+        Algorithm::RS512 => Box::new(rsa::Rsa512Signer::new(key)?) as Box<dyn JwtSigner>,
+        Algorithm::PS256 => Box::new(rsa::RsaPss256Signer::new(key)?) as Box<dyn JwtSigner>,
+        Algorithm::PS384 => Box::new(rsa::RsaPss384Signer::new(key)?) as Box<dyn JwtSigner>,
+        Algorithm::PS512 => Box::new(rsa::RsaPss512Signer::new(key)?) as Box<dyn JwtSigner>,
+        Algorithm::EdDSA => Box::new(eddsa::EdDSASigner::new(key)?) as Box<dyn JwtSigner>,
+    };
+
+    Ok(jwt_signer)
+}
+
+fn new_verifier(
+    algorithm: &Algorithm,
+    key: &DecodingKey,
+) -> Result<Box<dyn super::JwtVerifier>, Error> {
+    let jwt_verifier = match algorithm {
+        Algorithm::HS256 => Box::new(hmac::Hs256Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        Algorithm::HS384 => Box::new(hmac::Hs384Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        Algorithm::HS512 => Box::new(hmac::Hs512Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        Algorithm::ES256 => Box::new(ecdsa::Es256Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        Algorithm::ES384 => Box::new(ecdsa::Es384Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        Algorithm::RS256 => Box::new(rsa::Rsa256Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        Algorithm::RS384 => Box::new(rsa::Rsa384Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        Algorithm::RS512 => Box::new(rsa::Rsa512Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        Algorithm::PS256 => Box::new(rsa::RsaPss256Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        Algorithm::PS384 => Box::new(rsa::RsaPss384Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        Algorithm::PS512 => Box::new(rsa::RsaPss512Verifier::new(key)?) as Box<dyn JwtVerifier>,
+        Algorithm::EdDSA => Box::new(eddsa::EdDSAVerifier::new(key)?) as Box<dyn JwtVerifier>,
+    };
+
+    Ok(jwt_verifier)
+}
+
+/// The default [`CryptoProvider`] backed by [`openssl`](https://github.com/sfackler/rust-openssl).
+pub static DEFAULT_PROVIDER: CryptoProvider = CryptoProvider {
+    signer_factory: new_signer,
+    verifier_factory: new_verifier,
+    key_utils: KeyUtils {
+        rsa_pub_components_from_private_key: rsa_components_from_private_key,
+        rsa_pub_components_from_public_key: rsa_components_from_public_key,
+        ec_pub_components_from_private_key: ec_components_from_private_key,
+        compute_digest,
+    },
+};

--- a/src/crypto/openssl/rsa.rs
+++ b/src/crypto/openssl/rsa.rs
@@ -1,0 +1,159 @@
+//! Implementations of the [`JwtSigner`] and [`JwtVerifier`] traits for the
+//! RSA family of algorithms using `openssl`.
+
+use openssl::bn::BigNum;
+use openssl::hash::MessageDigest;
+use openssl::pkey::PKey;
+use openssl::rsa::{Padding, Rsa};
+use openssl::sign::{RsaPssSaltlen, Signer as OsslSigner, Verifier as OsslVerifier};
+use signature::{Signer, Verifier};
+
+use crate::algorithms::AlgorithmFamily;
+use crate::crypto::{JwtSigner, JwtVerifier};
+use crate::decoding::DecodingKeyKind;
+use crate::errors::{ErrorKind, Result, new_error};
+use crate::{Algorithm, DecodingKey, EncodingKey};
+
+fn try_sign_rsa(
+    encoding_key: &EncodingKey,
+    msg: &[u8],
+    digest: MessageDigest,
+    pss: bool,
+) -> std::result::Result<Vec<u8>, signature::Error> {
+    let rsa = Rsa::private_key_from_der(encoding_key.inner())
+        .map_err(signature::Error::from_source)?;
+    let pkey = PKey::from_rsa(rsa).map_err(signature::Error::from_source)?;
+    let mut signer =
+        OsslSigner::new(digest, &pkey).map_err(signature::Error::from_source)?;
+
+    if pss {
+        signer
+            .set_rsa_padding(Padding::PKCS1_PSS)
+            .map_err(signature::Error::from_source)?;
+        signer
+            .set_rsa_pss_saltlen(RsaPssSaltlen::DIGEST_LENGTH)
+            .map_err(signature::Error::from_source)?;
+    }
+
+    signer.update(msg).map_err(signature::Error::from_source)?;
+    signer.sign_to_vec().map_err(signature::Error::from_source)
+}
+
+fn verify_rsa(
+    decoding_key: &DecodingKey,
+    msg: &[u8],
+    signature: &[u8],
+    digest: MessageDigest,
+    pss: bool,
+) -> std::result::Result<(), signature::Error> {
+    let pkey = match decoding_key.kind() {
+        DecodingKeyKind::SecretOrDer(bytes) => {
+            let rsa = Rsa::public_key_from_der_pkcs1(bytes)
+                .map_err(signature::Error::from_source)?;
+            PKey::from_rsa(rsa).map_err(signature::Error::from_source)?
+        }
+        DecodingKeyKind::RsaModulusExponent { n, e } => {
+            let bn_n = BigNum::from_slice(n).map_err(signature::Error::from_source)?;
+            let bn_e = BigNum::from_slice(e).map_err(signature::Error::from_source)?;
+            let rsa = Rsa::from_public_components(bn_n, bn_e)
+                .map_err(signature::Error::from_source)?;
+            PKey::from_rsa(rsa).map_err(signature::Error::from_source)?
+        }
+    };
+
+    let mut verifier =
+        OsslVerifier::new(digest, &pkey).map_err(signature::Error::from_source)?;
+
+    if pss {
+        verifier
+            .set_rsa_padding(Padding::PKCS1_PSS)
+            .map_err(signature::Error::from_source)?;
+        verifier
+            .set_rsa_pss_saltlen(RsaPssSaltlen::DIGEST_LENGTH)
+            .map_err(signature::Error::from_source)?;
+    }
+
+    verifier.update(msg).map_err(signature::Error::from_source)?;
+    if verifier
+        .verify(signature)
+        .map_err(signature::Error::from_source)?
+    {
+        Ok(())
+    } else {
+        Err(signature::Error::new())
+    }
+}
+
+macro_rules! define_rsa_signer {
+    ($name:ident, $alg:expr, $digest:expr, pss = $pss:expr) => {
+        pub struct $name(EncodingKey);
+
+        impl $name {
+            pub(crate) fn new(encoding_key: &EncodingKey) -> Result<Self> {
+                if encoding_key.family() != AlgorithmFamily::Rsa {
+                    return Err(new_error(ErrorKind::InvalidKeyFormat));
+                }
+
+                Ok(Self(encoding_key.clone()))
+            }
+        }
+
+        impl Signer<Vec<u8>> for $name {
+            fn try_sign(&self, msg: &[u8]) -> std::result::Result<Vec<u8>, signature::Error> {
+                try_sign_rsa(&self.0, msg, $digest, $pss)
+            }
+        }
+
+        impl JwtSigner for $name {
+            fn algorithm(&self) -> Algorithm {
+                $alg
+            }
+        }
+    };
+}
+
+macro_rules! define_rsa_verifier {
+    ($name:ident, $alg:expr, $digest:expr, pss = $pss:expr) => {
+        pub struct $name(DecodingKey);
+
+        impl $name {
+            pub(crate) fn new(decoding_key: &DecodingKey) -> Result<Self> {
+                if decoding_key.family() != AlgorithmFamily::Rsa {
+                    return Err(new_error(ErrorKind::InvalidKeyFormat));
+                }
+
+                Ok(Self(decoding_key.clone()))
+            }
+        }
+
+        impl Verifier<Vec<u8>> for $name {
+            fn verify(
+                &self,
+                msg: &[u8],
+                signature: &Vec<u8>,
+            ) -> std::result::Result<(), signature::Error> {
+                verify_rsa(&self.0, msg, signature, $digest, $pss)
+            }
+        }
+
+        impl JwtVerifier for $name {
+            fn algorithm(&self) -> Algorithm {
+                $alg
+            }
+        }
+    };
+}
+
+define_rsa_signer!(Rsa256Signer, Algorithm::RS256, MessageDigest::sha256(), pss = false);
+define_rsa_signer!(Rsa384Signer, Algorithm::RS384, MessageDigest::sha384(), pss = false);
+define_rsa_signer!(Rsa512Signer, Algorithm::RS512, MessageDigest::sha512(), pss = false);
+define_rsa_signer!(RsaPss256Signer, Algorithm::PS256, MessageDigest::sha256(), pss = true);
+define_rsa_signer!(RsaPss384Signer, Algorithm::PS384, MessageDigest::sha384(), pss = true);
+define_rsa_signer!(RsaPss512Signer, Algorithm::PS512, MessageDigest::sha512(), pss = true);
+
+define_rsa_verifier!(Rsa256Verifier, Algorithm::RS256, MessageDigest::sha256(), pss = false);
+define_rsa_verifier!(Rsa384Verifier, Algorithm::RS384, MessageDigest::sha384(), pss = false);
+define_rsa_verifier!(Rsa512Verifier, Algorithm::RS512, MessageDigest::sha512(), pss = false);
+define_rsa_verifier!(RsaPss256Verifier, Algorithm::PS256, MessageDigest::sha256(), pss = true);
+define_rsa_verifier!(RsaPss384Verifier, Algorithm::PS384, MessageDigest::sha384(), pss = true);
+define_rsa_verifier!(RsaPss512Verifier, Algorithm::PS512, MessageDigest::sha512(), pss = true);


### PR DESCRIPTION
This pull request adds support for using the `openssl` crate as a cryptographic backend for JWT signing and verification. It introduces a new optional `openssl` feature, implements all required cryptographic algorithms (HMAC, ECDSA, EdDSA, RSA) using OpenSSL, and integrates this provider into the crate’s feature selection logic. This allows users to choose OpenSSL as their cryptographic provider, alongside the existing `rust_crypto` and `aws_lc_rs` options.

This update provides an additional, widely used cryptographic backend option for users, improving flexibility and compatibility.