### PR TITLE
Clarify default nbf validation behavior in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ openssl pkcs8 -topk8 -nocrypt -in sec1.pem -out pkcs8.pem
 
 
 ## Validation
-This library automatically validates the `exp` claim, and `nbf` is validated if present. You can also validate the `sub`, `iss`, and `aud` but
+This library automatically validates the `exp` claim. The `nbf` claim can also be validated when present by enabling `validate_nbf` in the `Validation` struct. By default, `nbf` validation is disabled. You can also validate the `sub`, `iss`, and `aud` but
 those require setting the expected values in the `Validation` struct. In the case of `aud`, if there is a value set in the token but
 not in the `Validation`, the token will be rejected.
 


### PR DESCRIPTION
Clarify the documentation around `nbf` validation behavior.

While reading the README, I understood that `nbf` is automatically validated whenever it is present. However, after checking the `Validation` defaults, I found that `nbf` validation is disabled by default (`validate_nbf = false`).

This update makes the documentation explicit:

* `exp` is validated by default.
* `nbf` validation is supported but must be enabled explicitly.

This avoids possible confusion for users relying on the default `Validation` configuration.