### PR TITLE
Update the coordinated RustCrypto dependency stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
                 run: cargo install wasm-pack
 
             -   name: Run tests default features
-                run: wasm-pack test --node --features rust_crypto,getrandom/js
+                run: wasm-pack test --node --features rust_crypto,getrandom/wasm_js
 
             -   name: Run tests no features
-                run: wasm-pack test --node --no-default-features --features rust_crypto,getrandom/js
+                run: wasm-pack test --node --no-default-features --features rust_crypto,getrandom/wasm_js

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ features = ["rust_crypto"]
 base64 = "0.22"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0"
-signature = { version = "2.2.0", features = ["std"] }
+signature = { version = "3", features = ["alloc", "rand_core"] }
 
 # For PEM decoding
 pem = { version = "3", optional = true }
@@ -36,15 +36,16 @@ simple_asn1 = { version = "0.6", optional = true }
 aws-lc-rs = { version = "1.15.0", optional = true }
 
 # "rust_crypto" feature
-ed25519-dalek = { version = "2.1.1", optional = true, features = ["pkcs8"] }
-hmac = { version = "0.12.1", optional = true, features = ["reset"] }
-p256 = { version = "0.13.2", optional = true, features = ["ecdsa"] }
-p384 = { version = "0.13.0", optional = true, features = ["ecdsa"] }
-rand = { version = "0.8.5", optional = true, features = [
+ed25519-dalek = { version = "3", optional = true, features = ["pkcs8"] }
+hmac = { version = "0.13", optional = true }
+p256 = { version = "0.14", optional = true, features = ["ecdsa"] }
+p384 = { version = "0.14", optional = true, features = ["ecdsa"] }
+rand = { version = "0.10", optional = true, features = [
     "std",
+    "thread_rng",
 ], default-features = false }
-rsa = { version = "0.9.6", optional = true }
-sha2 = { version = "0.10.7", optional = true, features = ["oid"] }
+rsa = { version = "0.10.0-rc.18", optional = true }
+sha2 = { version = "0.11", optional = true, features = ["oid"] }
 zeroize = { version = "1.8.2", features = ["derive"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -53,9 +54,8 @@ getrandom = "0.2"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.1"
-ed25519-dalek = { version = "2.1.1", features = ["pkcs8", "rand_core"] }
-rand = { version = "0.8.5", features = ["std"], default-features = false }
-rand_core = "0.6.4"
+ed25519-dalek = { version = "3", features = ["alloc", "pkcs8", "rand_core"] }
+rand = { version = "0.10", features = ["std", "thread_rng"], default-features = false }
 [target.'cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))'.dev-dependencies]
 # For the custom time example
 time = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ zeroize = { version = "1.8.2", features = ["derive"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"
-getrandom = "0.2"
+getrandom = "0.4"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.1"

--- a/examples/ed25519.rs
+++ b/examples/ed25519.rs
@@ -1,6 +1,5 @@
 use ed25519_dalek::SigningKey;
 use ed25519_dalek::pkcs8::EncodePrivateKey;
-use rand_core::OsRng;
 use serde::{Deserialize, Serialize};
 
 use jsonwebtoken::{
@@ -14,7 +13,7 @@ pub struct Claims {
 }
 
 fn main() {
-    let signing_key = SigningKey::generate(&mut OsRng);
+    let signing_key = SigningKey::generate(&mut rand::rng());
     let pkcs8 = signing_key.to_pkcs8_der().unwrap();
     let pkcs8 = pkcs8.as_bytes();
     // The `to_pkcs8_der` includes the public key, the first 48 bits are the private key.
@@ -45,7 +44,7 @@ mod tests {
 
     impl Jot {
         fn new() -> Jot {
-            let signing_key = SigningKey::generate(&mut OsRng);
+            let signing_key = SigningKey::generate(&mut rand::rng());
             let pkcs8 = signing_key.to_pkcs8_der().unwrap();
             let pkcs8 = pkcs8.as_bytes();
             // The `to_pkcs8_der` includes the public key, the first 48 bits are the private key.

--- a/src/crypto/rust_crypto/ecdsa.rs
+++ b/src/crypto/rust_crypto/ecdsa.rs
@@ -33,7 +33,7 @@ macro_rules! define_ecdsa_signer {
 
         impl Signer<Vec<u8>> for $name {
             fn try_sign(&self, msg: &[u8]) -> std::result::Result<Vec<u8>, Error> {
-                let signature = self.0.sign_recoverable(msg).map_err(Error::from_source)?.0;
+                let signature = self.0.sign_recoverable(msg).0;
                 Ok(signature.to_vec())
             }
         }

--- a/src/crypto/rust_crypto/hmac.rs
+++ b/src/crypto/rust_crypto/hmac.rs
@@ -1,7 +1,7 @@
 //! Implementations of the [`JwtSigner`] and [`JwtVerifier`] traits for the
 //! HMAC family of algorithms using `RustCrypto`'s [`hmac`].
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::{Sha256, Sha384, Sha512};
 use signature::{Signer, Verifier};
 
@@ -34,7 +34,6 @@ macro_rules! define_hmac_signer {
         impl Signer<Vec<u8>> for $name {
             fn try_sign(&self, msg: &[u8]) -> std::result::Result<Vec<u8>, signature::Error> {
                 let mut signer = self.0.clone();
-                signer.reset();
                 signer.update(msg);
 
                 Ok(signer.finalize().into_bytes().to_vec())
@@ -74,7 +73,6 @@ macro_rules! define_hmac_verifier {
                 signature: &Vec<u8>,
             ) -> std::result::Result<(), signature::Error> {
                 let mut verifier = self.0.clone();
-                verifier.reset();
                 verifier.update(msg);
 
                 verifier.verify_slice(signature).map_err(signature::Error::from_source)

--- a/src/crypto/rust_crypto/mod.rs
+++ b/src/crypto/rust_crypto/mod.rs
@@ -24,13 +24,19 @@ fn rsa_components_from_private_key(key_content: &[u8]) -> errors::Result<(Vec<u8
     let private_key = RsaPrivateKey::from_pkcs1_der(key_content)
         .map_err(|e| ErrorKind::InvalidRsaKey(e.to_string()))?;
     let public_key = private_key.to_public_key();
-    Ok((public_key.n().to_bytes_be(), public_key.e().to_bytes_be()))
+    Ok((
+        public_key.n().as_ref().to_be_bytes_trimmed_vartime().into_vec(),
+        public_key.e().to_be_bytes_trimmed_vartime().into_vec(),
+    ))
 }
 
 fn rsa_components_from_public_key(key_content: &[u8]) -> errors::Result<(Vec<u8>, Vec<u8>)> {
     let public_key = RsaPublicKey::from_pkcs1_der(key_content)
         .map_err(|e| ErrorKind::InvalidRsaKey(e.to_string()))?;
-    Ok((public_key.n().to_bytes_be(), public_key.e().to_bytes_be()))
+    Ok((
+        public_key.n().as_ref().to_be_bytes_trimmed_vartime().into_vec(),
+        public_key.e().to_be_bytes_trimmed_vartime().into_vec(),
+    ))
 }
 
 fn ec_components_from_private_key(
@@ -42,7 +48,7 @@ fn ec_components_from_private_key(
             let signing_key = P256SigningKey::from_pkcs8_der(key_content)
                 .map_err(|_| ErrorKind::InvalidEcdsaKey)?;
             let public_key = signing_key.verifying_key();
-            let encoded = public_key.to_encoded_point(false);
+            let encoded = public_key.to_sec1_point(false);
             match encoded.coordinates() {
                 p256::elliptic_curve::sec1::Coordinates::Uncompressed { x, y } => {
                     Ok((EllipticCurve::P256, x.to_vec(), y.to_vec()))
@@ -54,7 +60,7 @@ fn ec_components_from_private_key(
             let signing_key = P384SigningKey::from_pkcs8_der(key_content)
                 .map_err(|_| ErrorKind::InvalidEcdsaKey)?;
             let public_key = signing_key.verifying_key();
-            let encoded = public_key.to_encoded_point(false);
+            let encoded = public_key.to_sec1_point(false);
             match encoded.coordinates() {
                 p384::elliptic_curve::sec1::Coordinates::Uncompressed { x, y } => {
                     Ok((EllipticCurve::P384, x.to_vec(), y.to_vec()))

--- a/src/crypto/rust_crypto/rsa.rs
+++ b/src/crypto/rust_crypto/rsa.rs
@@ -2,7 +2,7 @@
 //! RSA family of algorithms using RustCrypto.
 
 use rsa::{
-    BigUint, Pkcs1v15Sign, Pss, RsaPublicKey,
+    BoxedUint, Pkcs1v15Sign, Pss, RsaPublicKey,
     pkcs1::{DecodeRsaPrivateKey, DecodeRsaPublicKey},
     pkcs1v15::SigningKey,
     pkcs8::AssociatedOid,
@@ -29,7 +29,7 @@ fn try_sign_rsa<H>(
 where
     H: Digest + AssociatedOid + FixedOutputReset,
 {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let private_key = rsa::RsaPrivateKey::from_pkcs1_der(encoding_key.as_bytes())
         .map_err(signature::Error::from_source)?;
     if pss {
@@ -57,9 +57,12 @@ fn verify_rsa<S: SignatureScheme, H: Digest + AssociatedOid>(
                 .map_err(signature::Error::from_source)?;
         }
         DecodingKeyKind::RsaModulusExponent { n, e } => {
-            RsaPublicKey::new(BigUint::from_bytes_be(n), BigUint::from_bytes_be(e))?
-                .verify(scheme, &digest, signature)
-                .map_err(signature::Error::from_source)?;
+            RsaPublicKey::new(
+                BoxedUint::from_be_slice_vartime(n),
+                BoxedUint::from_be_slice_vartime(e),
+            )?
+            .verify(scheme, &digest, signature)
+            .map_err(signature::Error::from_source)?;
         }
     };
 
@@ -115,7 +118,7 @@ macro_rules! define_rsa_verifier {
                 signature: &Vec<u8>,
             ) -> std::result::Result<(), signature::Error> {
                 if $pss {
-                    verify_rsa::<Pss, $hash>(Pss::new::<$hash>(), &self.0, msg, signature)
+                    verify_rsa::<Pss<$hash>, $hash>(Pss::<$hash>::new(), &self.0, msg, signature)
                 } else {
                     verify_rsa::<_, $hash>(Pkcs1v15Sign::new::<$hash>(), &self.0, msg, signature)
                 }


### PR DESCRIPTION
Builds on the direction discussed in #502, particularly the recommendation to update the full RustCrypto family together rather than carry duplicate `hybrid-array`/`crypto-common`/`digest`/`signature` generations.

This updates:
- `signature` 2 -> 3
- `hmac` 0.12 -> 0.13
- `sha2` 0.10 -> 0.11
- `p256`/`p384` 0.13 -> 0.14
- `ed25519-dalek` 2 -> 3
- `rsa` 0.9 -> 0.10.0-rc.18
- `rand` 0.8 -> 0.10

The implementation changes are API migrations only: HMAC no longer resets a freshly cloned state, RSA uses `BoxedUint`, ECDSA uses the updated infallible recoverable-signature API, and the Ed25519 example uses the current RNG API.

The RSA prerelease requirement is an ordinary Cargo caret requirement. It permits newer prereleases of `0.10.0` and automatically permits the final `0.10.0` and later compatible `0.10.x` versions once published. An existing application lockfile still requires its normal dependency update cycle.

Validated locally:
- `cargo fmt --check`
- `cargo check --all-features`
- `cargo clippy --all-targets --features rust_crypto -- -D warnings`
- `cargo clippy --all-targets --features aws_lc_rs -- -D warnings`
- `cargo test --features rust_crypto`
- `cargo test --features aws_lc_rs`

Related: #495 and #502.