### PR TITLE
feat: adding support for Unsecured JWT without signature algorithm type "none"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonwebtoken"
-version = "11.0.0"
+version = "11.0.1"
 authors = ["Vincent Prouillet <hello@vincentprouillet.com>"]
 license = "MIT"
 readme = "README.md"

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -15,6 +15,8 @@ pub enum AlgorithmFamily {
     Ec,
     /// Edwards curve public key family.
     Ed,
+    /// For Insecured JWT with "alg" : "none"
+    None,
 }
 
 impl AlgorithmFamily {
@@ -32,6 +34,7 @@ impl AlgorithmFamily {
             ],
             Self::Ec => &[Algorithm::ES256, Algorithm::ES384],
             Self::Ed => &[Algorithm::EdDSA],
+            Self::None => &[Algorithm::None],
         }
     }
 }
@@ -70,6 +73,10 @@ pub enum Algorithm {
 
     /// Edwards-curve Digital Signature Algorithm (EdDSA)
     EdDSA,
+    /// An Unsecured JWT is a JWS using the "alg" Header Parameter value "none"
+    /// https://datatracker.ietf.org/doc/html/rfc7519
+    #[serde(rename = "none")]
+    None,
 }
 
 impl FromStr for Algorithm {
@@ -88,6 +95,7 @@ impl FromStr for Algorithm {
             "PS512" => Ok(Algorithm::PS512),
             "RS512" => Ok(Algorithm::RS512),
             "EdDSA" => Ok(Algorithm::EdDSA),
+            "none" => Ok(Algorithm::None),
             _ => Err(ErrorKind::InvalidAlgorithmName.into()),
         }
     }
@@ -106,6 +114,7 @@ impl Algorithm {
             | Algorithm::PS512 => AlgorithmFamily::Rsa,
             Algorithm::ES256 | Algorithm::ES384 => AlgorithmFamily::Ec,
             Algorithm::EdDSA => AlgorithmFamily::Ed,
+            Algorithm::None => AlgorithmFamily::None,
         }
     }
 }
@@ -128,6 +137,7 @@ mod tests {
         assert!(Algorithm::from_str("PS256").is_ok());
         assert!(Algorithm::from_str("PS384").is_ok());
         assert!(Algorithm::from_str("PS512").is_ok());
+        assert!(Algorithm::from_str("none").is_ok());
         assert!(Algorithm::from_str("").is_err());
     }
 }

--- a/src/crypto/aws_lc/mod.rs
+++ b/src/crypto/aws_lc/mod.rs
@@ -6,6 +6,7 @@ use aws_lc_rs::{
     },
 };
 
+use crate::crypto::no_encryption;
 use crate::{
     Algorithm, DecodingKey, EncodingKey,
     crypto::{CryptoProvider, JwtSigner, JwtVerifier, KeyUtils},
@@ -93,6 +94,7 @@ fn new_signer(algorithm: &Algorithm, key: &EncodingKey) -> Result<Box<dyn JwtSig
         Algorithm::PS384 => Box::new(rsa::RsaPss384Signer::new(key)?) as Box<dyn JwtSigner>,
         Algorithm::PS512 => Box::new(rsa::RsaPss512Signer::new(key)?) as Box<dyn JwtSigner>,
         Algorithm::EdDSA => Box::new(eddsa::EdDSASigner::new(key)?) as Box<dyn JwtSigner>,
+        Algorithm::None => Box::new(no_encryption::NoEncryption::new()) as Box<dyn JwtSigner>,
     };
 
     Ok(jwt_signer)
@@ -115,6 +117,7 @@ fn new_verifier(
         Algorithm::PS384 => Box::new(rsa::RsaPss384Verifier::new(key)?) as Box<dyn JwtVerifier>,
         Algorithm::PS512 => Box::new(rsa::RsaPss512Verifier::new(key)?) as Box<dyn JwtVerifier>,
         Algorithm::EdDSA => Box::new(eddsa::EdDSAVerifier::new(key)?) as Box<dyn JwtVerifier>,
+        Algorithm::None => Box::new(no_encryption::NoEncryption::new()) as Box<dyn JwtVerifier>,
     };
 
     Ok(jwt_verifier)

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -18,6 +18,7 @@ use crate::{DecodingKey, EncodingKey};
 #[cfg(feature = "aws_lc_rs")]
 pub mod aws_lc;
 
+mod no_encryption;
 /// `RustCrypto` based CryptoProvider.
 #[cfg(feature = "rust_crypto")]
 pub mod rust_crypto;

--- a/src/crypto/no_encryption.rs
+++ b/src/crypto/no_encryption.rs
@@ -1,0 +1,35 @@
+use crate::Algorithm;
+use crate::crypto::{JwtSigner, JwtVerifier};
+use signature::{Error, Signer, Verifier};
+
+pub struct NoEncryption;
+
+impl NoEncryption {
+    pub fn new() -> Self {
+        NoEncryption
+    }
+}
+
+impl Verifier<Vec<u8>> for NoEncryption {
+    fn verify(&self, _msg: &[u8], _signature: &Vec<u8>) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl Signer<Vec<u8>> for NoEncryption {
+    fn try_sign(&self, _msg: &[u8]) -> std::result::Result<Vec<u8>, Error> {
+        Ok(vec![])
+    }
+}
+
+impl JwtSigner for NoEncryption {
+    fn algorithm(&self) -> Algorithm {
+        Algorithm::None
+    }
+}
+
+impl JwtVerifier for NoEncryption {
+    fn algorithm(&self) -> Algorithm {
+        Algorithm::None
+    }
+}

--- a/src/crypto/rust_crypto/mod.rs
+++ b/src/crypto/rust_crypto/mod.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha256, Sha384, Sha512};
 
 use crate::{
     Algorithm, DecodingKey, EncodingKey,
-    crypto::{CryptoProvider, JwtSigner, JwtVerifier, KeyUtils},
+    crypto::{CryptoProvider, JwtSigner, JwtVerifier, KeyUtils, no_encryption::NoEncryption},
     errors::{self, Error, ErrorKind},
     jwk::{EllipticCurve, ThumbprintHash},
 };
@@ -102,6 +102,7 @@ fn new_signer(algorithm: &Algorithm, key: &EncodingKey) -> Result<Box<dyn JwtSig
         Algorithm::PS384 => Box::new(rsa::RsaPss384Signer::new(key)?) as Box<dyn JwtSigner>,
         Algorithm::PS512 => Box::new(rsa::RsaPss512Signer::new(key)?) as Box<dyn JwtSigner>,
         Algorithm::EdDSA => Box::new(eddsa::EdDSASigner::new(key)?) as Box<dyn JwtSigner>,
+        Algorithm::None => Box::new(NoEncryption::new()) as Box<dyn JwtSigner>,
     };
 
     Ok(jwt_signer)
@@ -124,6 +125,7 @@ fn new_verifier(
         Algorithm::PS384 => Box::new(rsa::RsaPss384Verifier::new(key)?) as Box<dyn JwtVerifier>,
         Algorithm::PS512 => Box::new(rsa::RsaPss512Verifier::new(key)?) as Box<dyn JwtVerifier>,
         Algorithm::EdDSA => Box::new(eddsa::EdDSAVerifier::new(key)?) as Box<dyn JwtVerifier>,
+        Algorithm::None => Box::new(NoEncryption::new()) as Box<dyn JwtVerifier>,
     };
 
     Ok(jwt_verifier)

--- a/src/crypto/rust_crypto/no_encryption.rs
+++ b/src/crypto/rust_crypto/no_encryption.rs
@@ -1,0 +1,36 @@
+use crate::Algorithm;
+use signature::{Error, Signer, Verifier};
+use crate::crypto::{JwtVerifier,JwtSigner};
+
+pub struct NoEncryption;
+
+impl NoEncryption {
+    pub fn new() -> Self {
+        NoEncryption
+    }
+}
+
+impl Verifier<Vec<u8>> for NoEncryption {
+    fn verify(&self, _msg: &[u8], _signature: &Vec<u8>) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl Signer<Vec<u8>> for NoEncryption {
+    fn try_sign(&self, _msg: &[u8]) -> std::result::Result<Vec<u8>, Error> {
+        Ok(vec![])
+    }
+}
+
+impl JwtSigner for NoEncryption {
+    fn algorithm(&self) -> Algorithm {
+        Algorithm::None
+    }
+}
+
+
+impl JwtVerifier for NoEncryption {
+    fn algorithm(&self) -> Algorithm {
+        Algorithm::None
+    }
+}

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -236,6 +236,7 @@ impl From<Algorithm> for KeyAlgorithm {
             Algorithm::PS384 => KeyAlgorithm::PS384,
             Algorithm::PS512 => KeyAlgorithm::PS512,
             Algorithm::EdDSA => KeyAlgorithm::EdDSA,
+            Algorithm::None => KeyAlgorithm::UNKNOWN_ALGORITHM,
         }
     }
 }
@@ -547,25 +548,21 @@ impl Jwk {
                         x: b64_encode(public_key_bytes),
                     })
                 }
+                AlgorithmFamily::None => todo!(),
             },
         })
     }
 
     /// Create a `JWK` from a `DecodingKey`.
-    pub fn from_decoding_key(
-        key: &DecodingKey,
-        alg: Option<Algorithm>,
-    ) -> crate::errors::Result<Self> {
+    pub fn from_decoding_key(key: &DecodingKey, alg: Option<Algorithm>) -> errors::Result<Self> {
         Ok(Self {
             common: CommonParameters { key_algorithm: alg.map(|a| a.into()), ..Default::default() },
             algorithm: match key.family() {
-                crate::algorithms::AlgorithmFamily::Hmac => {
-                    AlgorithmParameters::OctetKey(OctetKeyParameters {
-                        key_type: OctetKeyType::Octet,
-                        value: b64_encode(key.try_get_as_bytes()?),
-                    })
-                }
-                crate::algorithms::AlgorithmFamily::Rsa => {
+                AlgorithmFamily::Hmac => AlgorithmParameters::OctetKey(OctetKeyParameters {
+                    key_type: OctetKeyType::Octet,
+                    value: b64_encode(key.try_get_as_bytes()?),
+                }),
+                AlgorithmFamily::Rsa => {
                     let (n, e) = match &key.kind() {
                         DecodingKeyKind::RsaModulusExponent { n, e } => {
                             (b64_encode(n), b64_encode(e))
@@ -582,7 +579,7 @@ impl Jwk {
 
                     AlgorithmParameters::RSA(RSAKeyParameters { key_type: RSAKeyType::RSA, n, e })
                 }
-                crate::algorithms::AlgorithmFamily::Ec => {
+                AlgorithmFamily::Ec => {
                     let (curve, x, y) = ec_pub_components_from_public_key(key.try_get_as_bytes()?)?;
                     AlgorithmParameters::EllipticCurve(EllipticCurveKeyParameters {
                         key_type: EllipticCurveKeyType::EC,
@@ -591,7 +588,7 @@ impl Jwk {
                         y: b64_encode(y),
                     })
                 }
-                crate::algorithms::AlgorithmFamily::Ed => {
+                AlgorithmFamily::Ed => {
                     let pub_bytes = key.try_get_as_bytes()?;
                     let (curve_type, x) = match pub_bytes.len() {
                         // ED25519: https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.5
@@ -605,6 +602,7 @@ impl Jwk {
                         x: b64_encode(x),
                     })
                 }
+                AlgorithmFamily::None => AlgorithmParameters::Other(Default::default()),
             },
         })
     }
@@ -618,8 +616,8 @@ impl Jwk {
                 EllipticCurve::P256 | EllipticCurve::P384 | EllipticCurve::P521 => {
                     format!(
                         r#"{{"crv":{},"kty":{},"x":"{}","y":"{}"}}"#,
-                        serde_json::to_string(&a.curve).unwrap(),
-                        serde_json::to_string(&a.key_type).unwrap(),
+                        serde_json::to_string(&a.curve)?,
+                        serde_json::to_string(&a.key_type)?,
                         a.x,
                         a.y,
                     )
@@ -632,16 +630,12 @@ impl Jwk {
                 format!(
                     r#"{{"e":"{}","kty":{},"n":"{}"}}"#,
                     a.e,
-                    serde_json::to_string(&a.key_type).unwrap(),
+                    serde_json::to_string(&a.key_type)?,
                     a.n,
                 )
             }
             AlgorithmParameters::OctetKey(a) => {
-                format!(
-                    r#"{{"k":"{}","kty":{}}}"#,
-                    a.value,
-                    serde_json::to_string(&a.key_type).unwrap()
-                )
+                format!(r#"{{"k":"{}","kty":{}}}"#, a.value, serde_json::to_string(&a.key_type)?)
             }
             AlgorithmParameters::OctetKeyPair(a) => match a.curve {
                 EllipticCurve::P256 | EllipticCurve::P384 | EllipticCurve::P521 => {
@@ -650,8 +644,8 @@ impl Jwk {
                 EllipticCurve::Ed25519 => {
                     format!(
                         r#"{{"crv":{},"kty":{},"x":"{}"}}"#,
-                        serde_json::to_string(&a.curve).unwrap(),
-                        serde_json::to_string(&a.key_type).unwrap(),
+                        serde_json::to_string(&a.curve)?,
+                        serde_json::to_string(&a.key_type)?,
                         a.x,
                     )
                 }
@@ -777,7 +771,7 @@ mod tests {
     #[wasm_bindgen_test]
     fn check_thumbprint() {
         let tp = Jwk {
-            common: crate::jwk::CommonParameters { key_id: Some("2011-04-29".to_string()), ..Default::default() },
+            common: CommonParameters { key_id: Some("2011-04-29".to_string()), ..Default::default() },
             algorithm: AlgorithmParameters::RSA(RSAKeyParameters {
                 key_type: crate::jwk::RSAKeyType::RSA,
                 n: "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw".to_string(),

--- a/tests/dangerous.rs
+++ b/tests/dangerous.rs
@@ -45,6 +45,22 @@ fn dangerous_insecure_decode_invalid_sig() {
 
 #[test]
 #[wasm_bindgen_test]
+fn dangerous_insecure_decode_no_sig_algorithm() {
+    let token = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJqb2huQGVtYWlsLmNvbSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjoxNTE2MjM5MDQwLCJhdWQiOlsianNvbndlYnRva2VudGVzdCJdfQ.";
+
+    let TokenData { header, claims } = insecure_decode::<Claims>(token).unwrap();
+
+    assert_eq!(Algorithm::None, header.alg);
+    assert_eq!(Some("JWT".to_string()), header.typ);
+
+    assert_eq!(vec!["jsonwebtokentest"], claims.aud);
+    assert_eq!("john@email.com", claims.sub);
+    assert_eq!(1516239022, claims.iat);
+    assert_eq!(1516239040, claims.exp);
+}
+
+#[test]
+#[wasm_bindgen_test]
 fn dangerous_insecure_decode_invalid_header() {
     let token = "badz.eyJhdWQiOlsianNvbndlYnRva2VudGVzdCJdLCJleHAiOjE3NTk4MjYyMTcsImlhdCI6MTc1OTgyNTkxNywic3ViIjoic3BpZmZlOi8vZXhhbXBsZS5vcmcvdGVzdHNlcnZpY2UifQ.sig";
 


### PR DESCRIPTION
# Unsecure JWTs Decoding
Here I add support for decoding JWT with header algorithm set to value "none". The RFC has it specified. But JSONWeb token library didn't support decoding such JWT and would always fail. I added None to the list of variants of Algorithm enums to be able to support unsecure jwt decoding.

Here is the RFC and the section of the pages where this is mentioned as a spec to JWT which jsonwebtoken lib didn't support.
https://datatracker.ietf.org/doc/html/rfc7519#page-12
<img width="1724" height="921" alt="image" src="https://github.com/user-attachments/assets/e7d70424-c933-4ca5-a194-b902bb738629" />
